### PR TITLE
CFM-963 Display "Not found" if get the version of cfm-service failed

### DIFF
--- a/webui/src/components/Footer.vue
+++ b/webui/src/components/Footer.vue
@@ -8,8 +8,11 @@
     class="d-flex align-center justify-center"
   >
     &copy; {{ new Date().getFullYear() }} Seagate | CFM Service Version:
-    {{ serviceVersion }} | CFM Web UI Version:
-    {{ uiVersion }}
+    <span :style="{ color: serviceVersion ? 'inherit' : 'red', margin: '8px' }">
+      {{ serviceVersion || "Not Found" }}
+    </span>
+    | CFM Web UI Version:
+    <span :style="{ margin: '8px' }"> {{ uiVersion }} </span>
   </v-card>
 </template>
 


### PR DESCRIPTION
Display "Not found" if get the version of cfm-service failed and mark it red. 
![image](https://github.com/Seagate/cfm/assets/71745861/58d83167-8543-4b95-a17c-a2e98fb6a4db)

