### PR TITLE
Reset the copyright footer

### DIFF
--- a/webui/src/components/Footer.vue
+++ b/webui/src/components/Footer.vue
@@ -7,8 +7,7 @@
     dark
     class="d-flex align-center justify-center"
   >
-    &copy; {{ new Date().getFullYear() }} Seagate Technology LLC | CFM Service
-    Version:
+    &copy; 2024 Seagate Technology LLC | CFM Service Version:
     <span :style="{ color: serviceVersion ? 'inherit' : 'red', margin: '8px' }">
       {{ serviceVersion || "Not Found" }}
     </span>


### PR DESCRIPTION
Reset the copyright footer to make it similar with Seagate Home Web.
Copyright footer in Seagate Home Web:
![image](https://github.com/Seagate/cfm/assets/71745861/4c834bc9-3911-4dad-a2c8-32c1a26e9898)
Copyright footer in cfm-webui:
![image](https://github.com/Seagate/cfm/assets/71745861/f523d7a2-95c3-460f-8bfe-b26141cc71ae)
