### PR TITLE
feat: Use Blade serial number as device ID

### DIFF
--- a/pkg/backend/ops.go
+++ b/pkg/backend/ops.go
@@ -15,6 +15,8 @@ type CreateSessionResponse struct {
 	SessionId    string // The session id returned form creating a session
 	Status       string // The status of the request
 	ServiceError error  // Any error returned by the service
+	ChassisSN    string // The serial number returned from the redfish chassis schema
+	EnclosureSN  string // The serial number returned from the redfish chassis schema for the enclosure
 }
 
 type DeleteSessionRequest struct {

--- a/pkg/manager/appliance.go
+++ b/pkg/manager/appliance.go
@@ -97,9 +97,12 @@ func (a *Appliance) AddBlade(ctx context.Context, c *openapi.Credentials) (*Blad
 	}
 
 	bladeId := c.CustomId
-	if bladeId == "" {
-		// Generate default id using last N digits of the session id combined with the default prefix
-		bladeId = fmt.Sprintf("%s-%s", ID_PREFIX_BLADE_DFLT, response.SessionId[(len(response.SessionId)-common.NumUuidCharsForId):])
+	if bladeId == "" { // Order CustomeId > BladeSN > UUID
+		bladeId = response.ChassisSN
+		if bladeId == "" {
+			// Generate default id using last N digits of the session id combined with the default prefix
+			bladeId = fmt.Sprintf("%s-%s", ID_PREFIX_BLADE_DFLT, response.SessionId[(len(response.SessionId)-common.NumUuidCharsForId):])
+		}
 	}
 
 	// Check for duplicate ID

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -209,9 +209,12 @@ func AddHost(ctx context.Context, c *openapi.Credentials) (*Host, error) {
 	}
 
 	hostId := c.CustomId
-	if hostId == "" {
-		// Generate default id using last N digits of the session id combined with the default prefix
-		hostId = fmt.Sprintf("%s-%s", ID_PREFIX_HOST_DFLT, response.SessionId[(len(response.SessionId)-common.NumUuidCharsForId):])
+	if hostId == "" { // Order CustomeId > HostSN > UUID
+		hostId = response.ChassisSN
+		if hostId == "" {
+			// Generate default id using last N digits of the session id combined with the default prefix
+			hostId = fmt.Sprintf("%s-%s", ID_PREFIX_HOST_DFLT, response.SessionId[(len(response.SessionId)-common.NumUuidCharsForId):])
+		}
 	}
 
 	// Check for duplicate ID.


### PR DESCRIPTION
Handle chassis collection with more than one member Check for optional CMA enclosure SN
Pass blade and enclosure SN back to manager layer
User BladeSN as bladeID when customID is not provided