### PR TITLE
Get cfm-service version in footer not dashboard

### DIFF
--- a/webui/src/components/Dashboard/Dashboard.vue
+++ b/webui/src/components/Dashboard/Dashboard.vue
@@ -60,7 +60,6 @@ import { useData } from "./initial-data-elements";
 import { useApplianceStore } from "../Stores/ApplianceStore";
 import { useHostStore } from "../Stores/HostStore";
 import { useBladeStore } from "../Stores/BladeStore";
-import { useServiceStore } from "../Stores/ServiceStore";
 import { useBladePortStore } from "../Stores/BladePortStore";
 import { VueFlow } from "@vue-flow/core";
 import { useRouter } from "vue-router";
@@ -73,7 +72,6 @@ export default {
     const applianceStore = useApplianceStore();
     const hostStore = useHostStore();
     const bladeStore = useBladeStore();
-    const serviceStore = useServiceStore();
     const bladePortStore = useBladePortStore();
 
     const router = useRouter();
@@ -176,7 +174,6 @@ export default {
 
     // Fetch appliances/blades/hosts when component is mounted
     onMounted(async () => {
-      await serviceStore.getServiceVersion();
       await applianceStore.fetchAppliances();
       await hostStore.fetchHosts();
       // Ensure blade ports are fetched after appliances, this action will create the edges for dataPlane

--- a/webui/src/components/Footer.vue
+++ b/webui/src/components/Footer.vue
@@ -18,16 +18,21 @@
 </template>
 
 <script>
-import { computed } from "vue";
+import { computed, onMounted } from "vue";
 import packageJson from "/package.json";
 import { useServiceStore } from "./Stores/ServiceStore";
 
 export default {
   setup() {
     const serviceStore = useServiceStore();
+
     const serviceVersion = computed(() => serviceStore.serviceVersion);
 
     const uiVersion = packageJson.version;
+
+    onMounted(() => {
+      serviceStore.getServiceVersion();
+    });
 
     return {
       serviceVersion,


### PR DESCRIPTION
Call the function to get the cfm-service version in the footer.
Before the fix, this function was called in the Dashboard component, if you refresh in other components, the browser will lose the cfm-service version.