### PR TITLE
feat: rename appliance/blade/host

### DIFF
--- a/api/cfm-openapi.yaml
+++ b/api/cfm-openapi.yaml
@@ -187,11 +187,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/statusMessage"
-
-  # Rename Memory Appliance
-  /cfm/v1/appliances/{applianceId}/rename:
-    post:
-      description: Rename the appliance ID.
+    put:
+      description: Rename an appliance by new id.
       operationId: appliancesRenameById
       parameters:
       - $ref: "#/components/parameters/applianceId"
@@ -366,11 +363,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/statusMessage"
-
-  # Rename Blade
-  /cfm/v1/appliances/{applianceId}/blades/{bladeId}/rename:
-    post:
-      description: Rename a blade by id.
+    put:
+      description: Rename a blade by new id.
       operationId: bladesRenameById
       parameters:
       - $ref: "#/components/parameters/applianceId"
@@ -885,11 +879,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/statusMessage"
-
-  # Rename CXL Host
-  /cfm/v1/hosts/{hostId}/rename:
-    post:
-      description: Rename a CXL Host by id.
+    put:
+      description: Rename a CXL host by new id.
       operationId: hostsRenameById
       parameters:
       - $ref: "#/components/parameters/hostId"
@@ -904,7 +895,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/blade'
+                $ref: '#/components/schemas/host'
         "400":
           description: Bad Request
           content:

--- a/api/cfm-openapi.yaml
+++ b/api/cfm-openapi.yaml
@@ -188,8 +188,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/statusMessage"
     put:
-      description: Rename an appliance by new id.
-      operationId: appliancesRenameById
+      description: Update an appliance with a new id.
+      operationId: appliancesUpdateById
       parameters:
       - $ref: "#/components/parameters/applianceId"
       - name: newApplianceId
@@ -364,8 +364,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/statusMessage"
     put:
-      description: Rename a blade by new id.
-      operationId: bladesRenameById
+      description: Update a blade with a new id.
+      operationId: bladesUpdateById
       parameters:
       - $ref: "#/components/parameters/applianceId"
       - $ref: "#/components/parameters/bladeId"
@@ -880,8 +880,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/statusMessage"
     put:
-      description: Rename a CXL host by new id.
-      operationId: hostsRenameById
+      description: Update a CXL host with a new id.
+      operationId: hostsUpdateById
       parameters:
       - $ref: "#/components/parameters/hostId"
       - name: newHostId

--- a/api/cfm-openapi.yaml
+++ b/api/cfm-openapi.yaml
@@ -188,6 +188,44 @@ paths:
               schema:
                 $ref: "#/components/schemas/statusMessage"
 
+  # Rename Memory Appliance
+  /cfm/v1/appliances/{applianceId}/rename:
+    post:
+      description: Rename the appliance ID.
+      operationId: appliancesRenameById
+      parameters:
+      - $ref: "#/components/parameters/applianceId"
+      - name: newApplianceId
+        in: query
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/appliance'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/statusMessage'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/statusMessage'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/statusMessage'
+
   # Memory Appliance Blades
   /cfm/v1/appliances/{applianceId}/blades:
     get:

--- a/api/cfm-openapi.yaml
+++ b/api/cfm-openapi.yaml
@@ -370,7 +370,7 @@ paths:
   # Rename Blade
   /cfm/v1/appliances/{applianceId}/blades/{bladeId}/rename:
     post:
-      description: Rename a memory blade by id.
+      description: Rename a blade by id.
       operationId: bladesRenameById
       parameters:
       - $ref: "#/components/parameters/applianceId"
@@ -885,6 +885,45 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/statusMessage"
+
+  # Rename CXL Host
+  /cfm/v1/hosts/{hostId}/rename:
+    post:
+      description: Rename a CXL Host by id.
+      operationId: hostsRenameById
+      parameters:
+      - $ref: "#/components/parameters/hostId"
+      - name: newHostId
+        in: query
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/blade'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/statusMessage'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/statusMessage'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/statusMessage"
+
   # CXL Host Ports
   /cfm/v1/hosts/{hostId}/ports:
     get:

--- a/api/cfm-openapi.yaml
+++ b/api/cfm-openapi.yaml
@@ -367,6 +367,45 @@ paths:
               schema:
                 $ref: "#/components/schemas/statusMessage"
 
+  # Rename Blade
+  /cfm/v1/appliances/{applianceId}/blades/{bladeId}/rename:
+    post:
+      description: Rename a memory blade by id.
+      operationId: bladesRenameById
+      parameters:
+      - $ref: "#/components/parameters/applianceId"
+      - $ref: "#/components/parameters/bladeId"
+      - name: newBladeId
+        in: query
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/blade'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/statusMessage'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/statusMessage'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/statusMessage"
+
   # Memory Blade Memory Resource Blocks
   /cfm/v1/appliances/{applianceId}/blades/{bladeId}/resources:
     get:

--- a/pkg/api/api_default_service.go
+++ b/pkg/api/api_default_service.go
@@ -523,7 +523,7 @@ func (cfm *CfmApiService) BladesGetPorts(ctx context.Context, applianceId string
 }
 
 // BladesRenameById -
-func (s *CfmApiService) BladesRenameById(ctx context.Context, applianceId string, bladeId string, newBladeId string) (openapi.ImplResponse, error) {
+func (cfm *CfmApiService) BladesRenameById(ctx context.Context, applianceId string, bladeId string, newBladeId string) (openapi.ImplResponse, error) {
 	appliance, err := manager.GetApplianceById(ctx, applianceId)
 	if err != nil {
 		return formatErrorResp(ctx, err.(*common.RequestError))
@@ -992,6 +992,30 @@ func (cfm *CfmApiService) HostsPost(ctx context.Context, credentials openapi.Cre
 	}
 
 	return openapi.Response(http.StatusCreated, h), nil
+}
+
+// HostsRenameById -
+func (cfm *CfmApiService) HostsRenameById(ctx context.Context, hostId string, newHostId string) (openapi.ImplResponse, error) {
+	// Make sure the hostId exists
+	// Get the host information from the manager level and is used for renaming
+	host, err := manager.GetHostById(ctx, hostId)
+	if err != nil {
+		return formatErrorResp(ctx, err.(*common.RequestError))
+	}
+
+	// Make sure the newHostId doesn't exist
+	existHost, err := manager.GetHostById(ctx, newHostId)
+	if existHost != nil {
+		return formatErrorResp(ctx, err.(*common.RequestError))
+	}
+
+	//Rename the cxl host with the new id
+	newHost, err := manager.RenameHost(ctx, host, newHostId)
+	if err != nil {
+		return formatErrorResp(ctx, err.(*common.RequestError))
+	}
+
+	return openapi.Response(http.StatusOK, newHost), nil
 }
 
 // HostsResync -

--- a/pkg/api/api_default_service.go
+++ b/pkg/api/api_default_service.go
@@ -143,8 +143,8 @@ func (cfm *CfmApiService) AppliancesPost(ctx context.Context, credentials openap
 	return openapi.Response(http.StatusCreated, a), nil
 }
 
-// AppliancesRenameById -
-func (cfm *CfmApiService) AppliancesRenameById(ctx context.Context, applianceId string, newApplianceId string) (openapi.ImplResponse, error) {
+// AppliancesUpdateById -
+func (cfm *CfmApiService) AppliancesUpdateById(ctx context.Context, applianceId string, newApplianceId string) (openapi.ImplResponse, error) {
 	// Make sure the newApplianceId doesn't exist
 	_, exist := manager.GetApplianceById(ctx, newApplianceId)
 	if exist == nil {
@@ -522,8 +522,8 @@ func (cfm *CfmApiService) BladesGetPorts(ctx context.Context, applianceId string
 	return openapi.Response(http.StatusOK, response), nil
 }
 
-// BladesRenameById -
-func (cfm *CfmApiService) BladesRenameById(ctx context.Context, applianceId string, bladeId string, newBladeId string) (openapi.ImplResponse, error) {
+// BladesUpdateById -
+func (cfm *CfmApiService) BladesUpdateById(ctx context.Context, applianceId string, bladeId string, newBladeId string) (openapi.ImplResponse, error) {
 	appliance, err := manager.GetApplianceById(ctx, applianceId)
 	if err != nil {
 		return formatErrorResp(ctx, err.(*common.RequestError))
@@ -994,8 +994,8 @@ func (cfm *CfmApiService) HostsPost(ctx context.Context, credentials openapi.Cre
 	return openapi.Response(http.StatusCreated, h), nil
 }
 
-// HostsRenameById -
-func (cfm *CfmApiService) HostsRenameById(ctx context.Context, hostId string, newHostId string) (openapi.ImplResponse, error) {
+// HostsUpdateById -
+func (cfm *CfmApiService) HostsUpdateById(ctx context.Context, hostId string, newHostId string) (openapi.ImplResponse, error) {
 	// Make sure the hostId exists
 	// Get the host information from the manager level and is used for renaming
 	host, err := manager.GetHostById(ctx, hostId)

--- a/pkg/api/api_default_service.go
+++ b/pkg/api/api_default_service.go
@@ -143,6 +143,33 @@ func (cfm *CfmApiService) AppliancesPost(ctx context.Context, credentials openap
 	return openapi.Response(http.StatusCreated, a), nil
 }
 
+// AppliancesRenameById -
+func (cfm *CfmApiService) AppliancesRenameById(ctx context.Context, applianceId string, newApplianceId string) (openapi.ImplResponse, error) {
+	// Make sure the newApplianceId doesn't exist
+	_, exist := manager.GetApplianceById(ctx, newApplianceId)
+	if exist == nil {
+		err := common.RequestError{
+			StatusCode: common.StatusApplianceIdDuplicate,
+			Err:        fmt.Errorf("the new name (%s) already exists", newApplianceId),
+		}
+		return formatErrorResp(ctx, &err)
+	}
+
+	// Make sure the appliance exists
+	appliance, err := manager.GetApplianceById(ctx, applianceId)
+	if err != nil {
+		return formatErrorResp(ctx, err.(*common.RequestError))
+	}
+
+	//Rename the appliance with the new id
+	newAppliance, err := manager.RenameAppliance(ctx, appliance, newApplianceId)
+	if err != nil {
+		return formatErrorResp(ctx, err.(*common.RequestError))
+	}
+
+	return openapi.Response(http.StatusOK, newAppliance), nil
+}
+
 // AppliancesResync -
 func (cfm *CfmApiService) AppliancesResyncById(ctx context.Context, applianceId string) (openapi.ImplResponse, error) {
 	appliance, err := manager.ResyncApplianceById(ctx, applianceId)

--- a/pkg/api/api_default_service.go
+++ b/pkg/api/api_default_service.go
@@ -549,7 +549,7 @@ func (cfm *CfmApiService) BladesUpdateById(ctx context.Context, applianceId stri
 	}
 
 	//Rename the appliance with the new id
-	newBlade, err := manager.RenameBlade(ctx, blade, newBladeId)
+	newBlade, err := manager.RenameBlade(ctx, appliance, blade, newBladeId)
 	if err != nil {
 		return formatErrorResp(ctx, err.(*common.RequestError))
 	}

--- a/pkg/api/api_default_service.go
+++ b/pkg/api/api_default_service.go
@@ -1004,9 +1004,13 @@ func (cfm *CfmApiService) HostsRenameById(ctx context.Context, hostId string, ne
 	}
 
 	// Make sure the newHostId doesn't exist
-	existHost, err := manager.GetHostById(ctx, newHostId)
-	if existHost != nil {
-		return formatErrorResp(ctx, err.(*common.RequestError))
+	_, exist := manager.GetHostById(ctx, newHostId)
+	if exist == nil {
+		err := common.RequestError{
+			StatusCode: common.StatusHostIdDuplicate,
+			Err:        fmt.Errorf("the new name (%s) already exists", newHostId),
+		}
+		return formatErrorResp(ctx, &err)
 	}
 
 	//Rename the cxl host with the new id

--- a/pkg/common/status.go
+++ b/pkg/common/status.go
@@ -60,6 +60,8 @@ const (
 	StatusBladeResyncFailure     //409
 	StatusHostResyncFailure      //409
 
+	StatusApplianceRenameFailure //409
+
 	StatusApplianceIdDuplicate //409
 	StatusBladeIdDuplicate     //409
 	StatusMemoryIdDuplicate    //409
@@ -176,6 +178,8 @@ func (e StatusCodeType) String() string {
 		return "Port Id Already Exist"
 	case StatusHostIdDuplicate:
 		return "Host Id Already Exist"
+	case StatusApplianceRenameFailure:
+		return "Rename Appliance Failure"
 	}
 	return "Unknown"
 
@@ -220,7 +224,8 @@ func (e StatusCodeType) HttpStatusCode() int {
 		StatusApplianceIdDuplicate,
 		StatusBladeIdDuplicate,
 		StatusPortIdDuplicate,
-		StatusHostIdDuplicate:
+		StatusHostIdDuplicate,
+		StatusApplianceRenameFailure:
 		return http.StatusConflict // 409
 	case StatusBackendInterfaceFailure,
 		StatusBladeCreateSessionFailure,

--- a/pkg/common/status.go
+++ b/pkg/common/status.go
@@ -61,6 +61,8 @@ const (
 	StatusHostResyncFailure      //409
 
 	StatusApplianceRenameFailure //409
+	StatusBladeRenameFailure     //409
+	StatusHostRenameFailure      //409
 
 	StatusApplianceIdDuplicate //409
 	StatusBladeIdDuplicate     //409
@@ -180,6 +182,10 @@ func (e StatusCodeType) String() string {
 		return "Host Id Already Exist"
 	case StatusApplianceRenameFailure:
 		return "Rename Appliance Failure"
+	case StatusBladeRenameFailure:
+		return "Rename Blade Failure"
+	case StatusHostRenameFailure:
+		return "Rename Host Failure"
 	}
 	return "Unknown"
 
@@ -225,7 +231,9 @@ func (e StatusCodeType) HttpStatusCode() int {
 		StatusBladeIdDuplicate,
 		StatusPortIdDuplicate,
 		StatusHostIdDuplicate,
-		StatusApplianceRenameFailure:
+		StatusApplianceRenameFailure,
+		StatusBladeRenameFailure,
+		StatusHostRenameFailure:
 		return http.StatusConflict // 409
 	case StatusBackendInterfaceFailure,
 		StatusBladeCreateSessionFailure,

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -140,9 +140,7 @@ func RenameAppliance(ctx context.Context, appliance *Appliance, newApplianceId s
 	// delete appliance and the associated blades
 	_, err := DeleteApplianceById(ctx, appliance.Id)
 	if err != nil {
-		newErr := fmt.Errorf("failed to delete appliance [%s]: %w", appliance.Id, err)
-		logger.Error(newErr, "failure: delete appliance by id")
-		return nil, &common.RequestError{StatusCode: common.StatusApplianceDeleteSessionFailure, Err: newErr}
+		return nil, &common.RequestError{StatusCode: common.StatusApplianceDeleteSessionFailure, Err: err}
 	}
 
 	// add appliance back with the new id
@@ -151,9 +149,7 @@ func RenameAppliance(ctx context.Context, appliance *Appliance, newApplianceId s
 	}
 	newAppliance, err := AddAppliance(ctx, &c)
 	if err != nil {
-		newErr := fmt.Errorf("failed to add appliance [%s]: %w", newApplianceId, err)
-		logger.Error(newErr, "failure: add appliance with new id")
-		return nil, &common.RequestError{StatusCode: common.StatusApplianceCreateSessionFailure, Err: newErr}
+		return nil, &common.RequestError{StatusCode: common.StatusApplianceCreateSessionFailure, Err: err}
 	}
 
 	var failedBladeIds []string
@@ -208,16 +204,12 @@ func RenameBlade(ctx context.Context, blade *Blade, newBladeId string) (*Blade, 
 	// delete blade
 	_, err := appliance.DeleteBladeById(ctx, blade.Id)
 	if err != nil {
-		newErr := fmt.Errorf("failed to delete blade [%s]: %w", blade.Id, err)
-		logger.Error(newErr, "failure: delete blade by id")
-		return nil, &common.RequestError{StatusCode: common.StatusBladeDeleteSessionFailure, Err: newErr}
+		return nil, &common.RequestError{StatusCode: common.StatusBladeRenameFailure, Err: err}
 	}
 	// Add the balde back with the new name
 	newBlade, err := appliance.AddBlade(ctx, c)
 	if err != nil {
-		newErr := fmt.Errorf("failed to add blade [%s]: %w", newBladeId, err)
-		logger.Error(newErr, "failure: add blade with new id")
-		return nil, &common.RequestError{StatusCode: common.StatusBladeCreateSessionFailure, Err: newErr}
+		return nil, &common.RequestError{StatusCode: common.StatusBladeRenameFailure, Err: err}
 	}
 	return newBlade, nil
 }
@@ -387,13 +379,13 @@ func RenameHost(ctx context.Context, host *Host, newHostId string) (*Host, error
 	// delete host
 	_, err := DeleteHostById(ctx, host.Id)
 	if err != nil {
-		return nil, err.(*common.RequestError)
+		return nil, &common.RequestError{StatusCode: common.StatusBladeRenameFailure, Err: err}
 	}
 
 	// Add the host back with the new name
 	newHost, err := AddHost(ctx, c)
 	if err != nil {
-		return nil, err.(*common.RequestError)
+		return nil, &common.RequestError{StatusCode: common.StatusBladeRenameFailure, Err: err}
 	}
 	return newHost, nil
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -370,6 +370,34 @@ func AddHost(ctx context.Context, c *openapi.Credentials) (*Host, error) {
 	return host, nil
 }
 
+func RenameHost(ctx context.Context, host *Host, newHostId string) (*Host, error) {
+	logger := klog.FromContext(ctx)
+	logger.V(4).Info(">>>>>> RenameHostById: ", "hostId", host.Id)
+	// Save the host credentials for adding back with the new name
+	c := &openapi.Credentials{
+		Username:  host.creds.Username,
+		Password:  host.creds.Password,
+		IpAddress: host.creds.IpAddress,
+		Port:      host.creds.Port,
+		Insecure:  host.creds.Insecure,
+		Protocol:  host.creds.Protocol,
+		CustomId:  newHostId,
+	}
+
+	// delete host
+	_, err := DeleteHostById(ctx, host.Id)
+	if err != nil {
+		return nil, err.(*common.RequestError)
+	}
+
+	// Add the host back with the new name
+	newHost, err := AddHost(ctx, c)
+	if err != nil {
+		return nil, err.(*common.RequestError)
+	}
+	return newHost, nil
+}
+
 func DeleteHostById(ctx context.Context, hostId string) (*Host, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(4).Info(">>>>>> DeleteHostById: ", "hostId", hostId)

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -123,18 +123,10 @@ func RenameAppliance(ctx context.Context, appliance *Appliance, newApplianceId s
 	logger := klog.FromContext(ctx)
 	logger.V(4).Info(">>>>>> RenameApplianceById: ", "applianceId", appliance.Id)
 
-	// query cache
-	existingAppliance, ok := deviceCache.GetApplianceByIdOk(appliance.Id)
-	if !ok {
-		newErr := fmt.Errorf("failed to get appliance [%s]", appliance.Id)
-		logger.Error(newErr, "failure: get appliance by id")
-		return nil, &common.RequestError{StatusCode: common.StatusApplianceIdDoesNotExist, Err: newErr}
-	}
-
 	// Store the associated blades information locally, which is needed when adding back the blades
 	bladesInfo := make(map[string]*Blade)
-	for _, id := range existingAppliance.GetAllBladeIds() {
-		bladesInfo[id] = existingAppliance.Blades[id]
+	for _, id := range appliance.GetAllBladeIds() {
+		bladesInfo[id] = appliance.Blades[id]
 	}
 
 	// delete appliance and the associated blades
@@ -178,17 +170,9 @@ func RenameAppliance(ctx context.Context, appliance *Appliance, newApplianceId s
 	}
 }
 
-func RenameBlade(ctx context.Context, blade *Blade, newBladeId string) (*Blade, error) {
+func RenameBlade(ctx context.Context, appliance *Appliance, blade *Blade, newBladeId string) (*Blade, error) {
 	logger := klog.FromContext(ctx)
 	logger.V(4).Info(">>>>>> RenameBladeById: ", "bladeId", blade.Id)
-
-	// query cache
-	appliance, ok := deviceCache.GetApplianceByIdOk(blade.ApplianceId)
-	if !ok {
-		newErr := fmt.Errorf("failed to get appliance [%s]", blade.ApplianceId)
-		logger.Error(newErr, "failure: get appliance by id")
-		return nil, &common.RequestError{StatusCode: common.StatusApplianceIdDoesNotExist, Err: newErr}
-	}
 
 	// Save the blade credentials for adding back with the new name
 	c := &openapi.Credentials{


### PR DESCRIPTION
Added three new APIs(AppliancesRenameById, BladesRenameById, HostsRenameById) to allow the user to rename the devices(appliance/blade/host).
The commands can be used to do testing: 
```
curl -s -X PUT http://localhost:8080/cfm/v1/appliances/{applianceId}?newApplianceId={newApplianceId} | jq
curl -s -X PUT http://localhost:8080/cfm/v1/appliances/{applianceId}/blade/{bladeId}?newBladeId={newBladeId} | jq
curl -s -X PUT http://localhost:8080/cfm/v1/hosts/{hostId}?newHostId={newHostId} | jq
```