### PR TITLE
Feat: display blade/host status in webui

### DIFF
--- a/webui/src/components/Appliance/Appliances.vue
+++ b/webui/src/components/Appliance/Appliances.vue
@@ -97,7 +97,8 @@
                   blade.ipAddress,
                   blade.port,
                   Number(blade.totalMemoryAvailableMiB),
-                  Number(blade.totalMemoryAllocatedMiB)
+                  Number(blade.totalMemoryAllocatedMiB),
+                  blade.status
                 )
               "
             >
@@ -169,24 +170,56 @@
                     </v-card-text>
                     <v-list lines="one">
                       <v-list-item>
+                        <v-list-item-title>Status</v-list-item-title>
+                        <v-list-item-subtitle>{{
+                          selectedBladeStatus
+                        }}</v-list-item-subtitle>
+                        <template v-slot:prepend>
+                          <v-avatar>
+                            <v-icon :color="statusColor"
+                              >{{statusIcon}}</v-icon
+                            >
+                          </v-avatar>
+                        </template>
+                      </v-list-item>
+                      <v-list-item>
                         <v-list-item-title prepend-icon="mdi-account-circle"
                           >Appliance Id</v-list-item-title
                         >
                         <v-list-item-subtitle>
                           {{ selectedApplianceId }}
                         </v-list-item-subtitle>
+                        <template v-slot:prepend>
+                          <v-avatar>
+                            <v-icon color="#6ebe4a"
+                              >mdi-account-circle</v-icon
+                            >
+                          </v-avatar>
+                        </template>
                       </v-list-item>
                       <v-list-item>
                         <v-list-item-title>Blade Id</v-list-item-title>
                         <v-list-item-subtitle>
                           {{ selectedBladeId }}
                         </v-list-item-subtitle>
+                        <template v-slot:prepend>
+                          <v-avatar>
+                            <v-icon color="#6ebe4a"
+                              >mdi-shield-account</v-icon
+                            >
+                          </v-avatar>
+                        </template>
                       </v-list-item>
                       <v-list-item>
                         <v-list-item-title>Ip Address</v-list-item-title>
                         <v-list-item-subtitle>
                           {{ selectedBladeIp + ":" + selectedBladePort }}
                         </v-list-item-subtitle>
+                        <template v-slot:prepend>
+                          <v-avatar>
+                            <v-icon color="#6ebe4a">mdi-ip</v-icon>
+                          </v-avatar>
+                        </template>
                       </v-list-item>
                     </v-list>
                   </v-card>
@@ -1224,7 +1257,8 @@ export default {
             defaultBlade!.ipAddress,
             defaultBlade!.port,
             Number(defaultBlade!.totalMemoryAvailableMiB),
-            Number(defaultBlade!.totalMemoryAllocatedMiB)
+            Number(defaultBlade!.totalMemoryAllocatedMiB),
+            defaultBlade!.status
           );
         }
         this.dialogAddBladeWait = false;
@@ -1281,7 +1315,8 @@ export default {
             defaultBlade.ipAddress,
             defaultBlade.port,
             Number(defaultBlade.totalMemoryAvailableMiB),
-            Number(defaultBlade.totalMemoryAllocatedMiB)
+            Number(defaultBlade.totalMemoryAllocatedMiB),
+            defaultBlade.status
           );
         }
         this.dialogDeleteBladeWait = false;
@@ -1444,7 +1479,8 @@ export default {
               selectedBlade.ipAddress,
               selectedBlade.port,
               Number(selectedBlade.totalMemoryAvailableMiB),
-              Number(selectedBlade.totalMemoryAllocatedMiB)
+              Number(selectedBlade.totalMemoryAllocatedMiB),
+              selectedBlade.status
             );
             // Update the URL with the first blade's ID
             updateUrlWithBladeId(newVal, selectedBlade.id);
@@ -1496,6 +1532,19 @@ export default {
     const selectedBladeId = computed(() => bladeStore.selectedBladeId);
     const selectedBladeIp = computed(() => bladeStore.selectedBladeIp);
     const selectedBladePort = computed(() => bladeStore.selectedBladePortNum);
+    const selectedBladeStatus = computed(() => bladeStore.selectedBladeStatus);
+    
+    const statusColor = computed(() => {
+      return selectedBladeStatus.value === "online"
+        ? "#6ebe4a"
+        : "warning";
+    });
+
+    const statusIcon = computed(() => {
+      return selectedBladeStatus.value === "online"
+        ? "mdi-check-circle"
+        : "mdi-close-circle";
+    });
 
     // Methods to update state
     const selectAppliance = (applianceId: string) => {
@@ -1506,14 +1555,16 @@ export default {
       bladeIp: string,
       bladePort: number,
       bladeMemoryAvailable: number,
-      bladeMemoryAllocated: number
+      bladeMemoryAllocated: number,
+      bladeStatus: string
     ) => {
       bladeStore.selectBlade(
         bladeId,
         bladeIp,
         bladePort,
         bladeMemoryAvailable,
-        bladeMemoryAllocated
+        bladeMemoryAllocated,
+        bladeStatus
       );
     };
 
@@ -1524,6 +1575,9 @@ export default {
       selectedBladeId,
       selectedBladePort,
       selectedBladeIp,
+      selectedBladeStatus,
+      statusColor,
+      statusIcon,
       selectAppliance,
       selectBlade,
       loading,

--- a/webui/src/components/Appliance/Appliances.vue
+++ b/webui/src/components/Appliance/Appliances.vue
@@ -171,9 +171,10 @@
                     <v-list lines="one">
                       <v-list-item>
                         <v-list-item-title>Status</v-list-item-title>
-                        <v-list-item-subtitle>{{
-                          selectedBladeStatus
-                        }}</v-list-item-subtitle>
+                        <v-list-item-subtitle
+                          :style="{ fontWeight: 'bold', color: statusColor }"
+                          >{{ selectedBladeStatus }}</v-list-item-subtitle
+                        >
                         <template v-slot:prepend>
                           <v-avatar>
                             <v-icon :color="statusColor">{{
@@ -1531,7 +1532,7 @@ export default {
     const selectedBladeStatus = computed(() => bladeStore.selectedBladeStatus);
 
     const statusColor = computed(() => {
-      return selectedBladeStatus.value === "online" ? "#6ebe4a" : "warning";
+      return selectedBladeStatus.value === "online" ? "#6ebe4a" : "#ff9f40";
     });
 
     const statusIcon = computed(() => {

--- a/webui/src/components/Appliance/Appliances.vue
+++ b/webui/src/components/Appliance/Appliances.vue
@@ -176,9 +176,9 @@
                         }}</v-list-item-subtitle>
                         <template v-slot:prepend>
                           <v-avatar>
-                            <v-icon :color="statusColor"
-                              >{{statusIcon}}</v-icon
-                            >
+                            <v-icon :color="statusColor">{{
+                              statusIcon
+                            }}</v-icon>
                           </v-avatar>
                         </template>
                       </v-list-item>
@@ -191,9 +191,7 @@
                         </v-list-item-subtitle>
                         <template v-slot:prepend>
                           <v-avatar>
-                            <v-icon color="#6ebe4a"
-                              >mdi-account-circle</v-icon
-                            >
+                            <v-icon color="#6ebe4a">mdi-account-circle</v-icon>
                           </v-avatar>
                         </template>
                       </v-list-item>
@@ -204,9 +202,7 @@
                         </v-list-item-subtitle>
                         <template v-slot:prepend>
                           <v-avatar>
-                            <v-icon color="#6ebe4a"
-                              >mdi-shield-account</v-icon
-                            >
+                            <v-icon color="#6ebe4a">mdi-shield-account</v-icon>
                           </v-avatar>
                         </template>
                       </v-list-item>
@@ -1533,11 +1529,9 @@ export default {
     const selectedBladeIp = computed(() => bladeStore.selectedBladeIp);
     const selectedBladePort = computed(() => bladeStore.selectedBladePortNum);
     const selectedBladeStatus = computed(() => bladeStore.selectedBladeStatus);
-    
+
     const statusColor = computed(() => {
-      return selectedBladeStatus.value === "online"
-        ? "#6ebe4a"
-        : "warning";
+      return selectedBladeStatus.value === "online" ? "#6ebe4a" : "warning";
     });
 
     const statusIcon = computed(() => {
@@ -1556,7 +1550,7 @@ export default {
       bladePort: number,
       bladeMemoryAvailable: number,
       bladeMemoryAllocated: number,
-      bladeStatus: string
+      bladeStatus: string | undefined
     ) => {
       bladeStore.selectBlade(
         bladeId,

--- a/webui/src/components/CXL-Hosts/CXL-Hosts.vue
+++ b/webui/src/components/CXL-Hosts/CXL-Hosts.vue
@@ -104,9 +104,13 @@
                 <v-list lines="one">
                   <v-list-item>
                     <v-list-item-title>Status</v-list-item-title>
-                    <v-list-item-subtitle>{{
-                      selectedHostStatus
-                    }}</v-list-item-subtitle>
+                    <v-list-item-subtitle
+                      :style="{
+                        fontWeight: 'bold',
+                        color: statusColor + ' !important',
+                      }"
+                      >{{ selectedHostStatus }}</v-list-item-subtitle
+                    >
                     <template v-slot:prepend>
                       <v-avatar>
                         <v-icon :color="statusColor">{{ statusIcon }}</v-icon>
@@ -915,7 +919,7 @@ export default {
     const selectedHostStatus = computed(() => hostStore.selectedHostStatus);
 
     const statusColor = computed(() => {
-      return selectedHostStatus.value === "online" ? "#6ebe4a" : "warning";
+      return selectedHostStatus.value === "online" ? "#6ebe4a" : "#ff9f40";
     });
 
     const statusIcon = computed(() => {

--- a/webui/src/components/CXL-Hosts/CXL-Hosts.vue
+++ b/webui/src/components/CXL-Hosts/CXL-Hosts.vue
@@ -31,7 +31,13 @@
           :key="host.id"
           :id="host.id"
           @click="
-            selectHost(host.id, host.ipAddress, host.port, host.localMemoryMiB)
+            selectHost(
+              host.id,
+              host.ipAddress,
+              host.port,
+              host.localMemoryMiB,
+              host.status
+            )
           "
         >
           <v-row justify="space-between" align="center">
@@ -69,13 +75,9 @@
           <!---First Row -->
           <!-- ---------------------------------------------- -->
           <v-row class="flex-0" dense>
-            <v-col cols="12" sm="12" md="12" lg="4">
+            <v-col cols="12" sm="6" md="6" lg="4">
               <!-- Basic Information -->
-              <v-card
-                class="card-shadow"
-                height="350"
-                color="rgba(110, 190, 74, 0.1)"
-              >
+              <v-card class="h-100" color="rgba(110, 190, 74, 0.1)">
                 <v-toolbar height="45">
                   <v-toolbar-title style="cursor: pointer"
                     >Basic Information</v-toolbar-title
@@ -101,16 +103,37 @@
                 </v-card-text>
                 <v-list lines="one">
                   <v-list-item>
+                    <v-list-item-title>Status</v-list-item-title>
+                    <v-list-item-subtitle>{{
+                      selectedHostStatus
+                    }}</v-list-item-subtitle>
+                    <template v-slot:prepend>
+                      <v-avatar>
+                        <v-icon :color="statusColor">{{ statusIcon }}</v-icon>
+                      </v-avatar>
+                    </template>
+                  </v-list-item>
+                  <v-list-item>
                     <v-list-item-title>CXL-Host Id</v-list-item-title>
                     <v-list-item-subtitle>
                       {{ host.id }}
                     </v-list-item-subtitle>
+                    <template v-slot:prepend>
+                      <v-avatar>
+                        <v-icon color="#6ebe4a">mdi-account-circle</v-icon>
+                      </v-avatar>
+                    </template>
                   </v-list-item>
                   <v-list-item>
                     <v-list-item-title>IpAddress</v-list-item-title>
                     <v-list-item-subtitle>
                       {{ host.ipAddress + ":" + host.port }}
                     </v-list-item-subtitle>
+                    <template v-slot:prepend>
+                      <v-avatar>
+                        <v-icon color="#6ebe4a">mdi-ip</v-icon>
+                      </v-avatar>
+                    </template>
                   </v-list-item>
                   <v-list-item>
                     <v-list-item-title>LocalMemoryGiB</v-list-item-title>
@@ -121,13 +144,18 @@
                           : "N/A"
                       }}
                     </v-list-item-subtitle>
+                    <template v-slot:prepend>
+                      <v-avatar>
+                        <v-icon color="#6ebe4a">mdi-memory</v-icon>
+                      </v-avatar>
+                    </template>
                   </v-list-item>
                 </v-list>
               </v-card>
             </v-col>
-            <v-col cols="12" sm="12" md="12" lg="8">
+            <v-col cols="12" sm="6" md="6" lg="8">
               <!-- Ports-->
-              <v-card class="card-shadow h-full" height="350">
+              <v-card class="h-100">
                 <v-toolbar height="45">
                   <v-toolbar-title style="cursor: pointer"
                     >Ports Information</v-toolbar-title
@@ -144,10 +172,10 @@
           <!-- ---------------------------------------------- -->
           <!---Second Row -->
           <!-- ---------------------------------------------- -->
-          <v-row class="card-shadow flex-grow-0" dense>
-            <v-col cols="12" sm="12" md="12" lg="6">
+          <v-row class="flex-0" dense>
+            <v-col cols="12" sm="6" md="6" lg="6">
               <!-- Memory Devices -->
-              <v-card class="card-shadow h-full" height="350">
+              <v-card class="h-100">
                 <v-toolbar height="45">
                   <v-toolbar-title style="cursor: pointer"
                     >Memory Devices</v-toolbar-title
@@ -160,9 +188,9 @@
                 </v-card-text>
               </v-card>
             </v-col>
-            <v-col cols="12" sm="12" md="12" lg="6">
+            <v-col cols="12" sm="12" md="6" lg="6">
               <!-- Memory -->
-              <v-card class="card-shadow h-full" height="350">
+              <v-card class="h-100">
                 <v-toolbar height="45">
                   <v-toolbar-title style="cursor: pointer"
                     >Memory</v-toolbar-title
@@ -687,7 +715,8 @@ export default {
             newHost?.id + "",
             newHost?.ipAddress + "",
             Number(newHost?.port),
-            newHost?.localMemoryMiB
+            newHost?.localMemoryMiB,
+            newHost?.status
           );
         }
         this.dialogAddHostWait = false;
@@ -730,7 +759,8 @@ export default {
             selectedHost.id,
             selectedHost.ipAddress,
             selectedHost.port,
-            selectedHost.localMemoryMiB
+            selectedHost.localMemoryMiB,
+            selectedHost.selectedBladeStatus
           );
         }
 
@@ -847,7 +877,8 @@ export default {
           selectedHost?.id + "",
           selectedHost?.ipAddress + "",
           Number(selectedHost?.port),
-          selectedHost?.localMemoryMiB
+          selectedHost?.localMemoryMiB,
+          selectedHost?.status
         );
       }
 
@@ -881,15 +912,33 @@ export default {
     const selectedHostId = computed(() => hostStore.selectedHostId);
     const selectedHostIp = computed(() => hostStore.selectedHostIp);
     const selectedHostPort = computed(() => hostStore.selectedHostPortNum);
+    const selectedHostStatus = computed(() => hostStore.selectedHostStatus);
+
+    const statusColor = computed(() => {
+      return selectedHostStatus.value === "online" ? "#6ebe4a" : "warning";
+    });
+
+    const statusIcon = computed(() => {
+      return selectedHostStatus.value === "online"
+        ? "mdi-check-circle"
+        : "mdi-close-circle";
+    });
 
     // Methods to update state
     const selectHost = (
       hostId: string,
       hostIp: string,
       hostPort: number,
-      hostLocalMemory: number | undefined
+      hostLocalMemory: number | undefined,
+      hostStatus: string
     ) => {
-      hostStore.selectHost(hostId, hostIp, hostPort, hostLocalMemory);
+      hostStore.selectHost(
+        hostId,
+        hostIp,
+        hostPort,
+        hostLocalMemory,
+        hostStatus
+      );
     };
 
     return {
@@ -897,6 +946,9 @@ export default {
       selectedHostId,
       selectedHostPort,
       selectedHostIp,
+      selectedHostStatus,
+      statusColor,
+      statusIcon,
       selectHost,
       loading,
     };

--- a/webui/src/components/CXL-Hosts/CXL-Hosts.vue
+++ b/webui/src/components/CXL-Hosts/CXL-Hosts.vue
@@ -760,7 +760,7 @@ export default {
             selectedHost.ipAddress,
             selectedHost.port,
             selectedHost.localMemoryMiB,
-            selectedHost.selectedBladeStatus
+            selectedHost.status
           );
         }
 
@@ -930,7 +930,7 @@ export default {
       hostIp: string,
       hostPort: number,
       hostLocalMemory: number | undefined,
-      hostStatus: string
+      hostStatus: string | undefined
     ) => {
       hostStore.selectHost(
         hostId,

--- a/webui/src/components/CXL-Hosts/HostMemory.vue
+++ b/webui/src/components/CXL-Hosts/HostMemory.vue
@@ -4,7 +4,7 @@
     <v-data-table
       :headers="headers"
       fixed-header
-      height="240"
+      height="300"
       :items="hostMemory"
     >
     </v-data-table>

--- a/webui/src/components/CXL-Hosts/HostMemoryDevice.vue
+++ b/webui/src/components/CXL-Hosts/HostMemoryDevice.vue
@@ -4,7 +4,7 @@
     <v-data-table
       :headers="headers"
       fixed-header
-      height="240"
+      height="300"
       :items="hostMemoryDevices"
     >
     </v-data-table>

--- a/webui/src/components/CXL-Hosts/HostPorts.vue
+++ b/webui/src/components/CXL-Hosts/HostPorts.vue
@@ -4,7 +4,7 @@
     <v-data-table
       :headers="headers"
       fixed-header
-      height="240"
+      height="300"
       :items="hostPorts"
     >
     </v-data-table>

--- a/webui/src/components/Stores/BladeStore.ts
+++ b/webui/src/components/Stores/BladeStore.ts
@@ -14,7 +14,7 @@ export const useBladeStore = defineStore('blade', {
         selectedBladePortNum: null as unknown as number,
         selectedBladeTotalMemoryAvailableMiB: null as unknown as number | undefined,
         selectedBladeTotalMemoryAllocatedMiB: null as unknown as number | undefined,
-        selectedBladeStatus: null as unknown as string,
+        selectedBladeStatus: null as unknown as string | undefined,
         addBladeError: null as unknown,
         deleteBladeError: null as unknown,
         resyncBladeError: null as unknown,
@@ -146,7 +146,7 @@ export const useBladeStore = defineStore('blade', {
         },
 
 
-        selectBlade(bladeId: string, selectedBladeIp: string, selectBladePortNum: number, selectedBladeTotalMemoryAvailableMiB: number, selectedBladeTotalMemoryAllocatedMiB: number, status: string) {
+        selectBlade(bladeId: string, selectedBladeIp: string, selectBladePortNum: number, selectedBladeTotalMemoryAvailableMiB: number, selectedBladeTotalMemoryAllocatedMiB: number, status: string | undefined) {
             this.selectedBladeId = bladeId;
             this.selectedBladeIp = selectedBladeIp;
             this.selectedBladePortNum = selectBladePortNum;

--- a/webui/src/components/Stores/BladeStore.ts
+++ b/webui/src/components/Stores/BladeStore.ts
@@ -14,6 +14,7 @@ export const useBladeStore = defineStore('blade', {
         selectedBladePortNum: null as unknown as number,
         selectedBladeTotalMemoryAvailableMiB: null as unknown as number | undefined,
         selectedBladeTotalMemoryAllocatedMiB: null as unknown as number | undefined,
+        selectedBladeStatus: null as unknown as string,
         addBladeError: null as unknown,
         deleteBladeError: null as unknown,
         resyncBladeError: null as unknown,
@@ -145,12 +146,13 @@ export const useBladeStore = defineStore('blade', {
         },
 
 
-        selectBlade(bladeId: string, selectedBladeIp: string, selectBladePortNum: number, selectedBladeTotalMemoryAvailableMiB: number, selectedBladeTotalMemoryAllocatedMiB: number) {
+        selectBlade(bladeId: string, selectedBladeIp: string, selectBladePortNum: number, selectedBladeTotalMemoryAvailableMiB: number, selectedBladeTotalMemoryAllocatedMiB: number, status: string) {
             this.selectedBladeId = bladeId;
             this.selectedBladeIp = selectedBladeIp;
             this.selectedBladePortNum = selectBladePortNum;
             this.selectedBladeTotalMemoryAvailableMiB = selectedBladeTotalMemoryAvailableMiB;
             this.selectedBladeTotalMemoryAllocatedMiB = selectedBladeTotalMemoryAllocatedMiB;
+            this.selectedBladeStatus = status;
         },
 
         updateSelectedBladeMemory(availableMemory: number | undefined, allocatedMemory: number | undefined) {

--- a/webui/src/components/Stores/HostStore.ts
+++ b/webui/src/components/Stores/HostStore.ts
@@ -14,7 +14,7 @@ export const useHostStore = defineStore('host', {
         selectedHostIp: null as unknown as string,
         selectedHostPortNum: null as unknown as number,
         selectedHostLocalMemory: null as unknown as number | undefined,
-        selectedHostStatus: null as unknown as string,
+        selectedHostStatus: null as unknown as string | undefined,
         addHostError: null as unknown,
         deleteHostError: null as unknown,
         resyncHostError: null as unknown,
@@ -124,7 +124,7 @@ export const useHostStore = defineStore('host', {
             }
         },
 
-        selectHost(selectedHostId: string, selectedHostIp: string, selectedHostPortNum: number, selectedHostLocalMemory: number | undefined, status: string) {
+        selectHost(selectedHostId: string, selectedHostIp: string, selectedHostPortNum: number, selectedHostLocalMemory: number | undefined, status: string | undefined) {
             this.selectedHostId = selectedHostId;
             this.selectedHostIp = selectedHostIp;
             this.selectedHostPortNum = selectedHostPortNum;

--- a/webui/src/components/Stores/HostStore.ts
+++ b/webui/src/components/Stores/HostStore.ts
@@ -14,6 +14,7 @@ export const useHostStore = defineStore('host', {
         selectedHostIp: null as unknown as string,
         selectedHostPortNum: null as unknown as number,
         selectedHostLocalMemory: null as unknown as number | undefined,
+        selectedHostStatus: null as unknown as string,
         addHostError: null as unknown,
         deleteHostError: null as unknown,
         resyncHostError: null as unknown,
@@ -123,11 +124,12 @@ export const useHostStore = defineStore('host', {
             }
         },
 
-        selectHost(selectedHostId: string, selectedHostIp: string, selectedHostPortNum: number, selectedHostLocalMemory: number | undefined) {
+        selectHost(selectedHostId: string, selectedHostIp: string, selectedHostPortNum: number, selectedHostLocalMemory: number | undefined, status: string) {
             this.selectedHostId = selectedHostId;
             this.selectedHostIp = selectedHostIp;
             this.selectedHostPortNum = selectedHostPortNum;
             this.selectedHostLocalMemory = selectedHostLocalMemory;
+            this.selectedHostStatus = status
         },
     }
 })


### PR DESCRIPTION
Display blade/host status in webui.
Blade online:
<img width="811" alt="image" src="https://github.com/user-attachments/assets/87a4c12c-6bf9-4713-a5a2-9ef94eaa5cc0">
Blade offline:
<img width="809" alt="image" src="https://github.com/user-attachments/assets/05fdb2ed-578d-4e33-b209-7e000620677d">
Host online:
<img width="805" alt="image" src="https://github.com/user-attachments/assets/b92b0a37-d1b0-4b72-9d3c-204d204fd9f1">
Host offline:
<img width="809" alt="image" src="https://github.com/user-attachments/assets/83e8bb5c-e79f-4238-aecb-7a8091161797">
