### PR TITLE
feat(service): implement new api DiscoverDevices

### DIFF
--- a/api/cfm-openapi.yaml
+++ b/api/cfm-openapi.yaml
@@ -1241,13 +1241,13 @@ components:
       schema:
         $ref: "#/components/schemas/id"
     deviceType:
-      description: Filter devices by type (either 'cma' or 'cxl-host')
+      description: Filter devices by type (either 'blade' or 'cxl-host')
       name: deviceType
       in: query
       required: true
       schema:
         type: string
-        enum: [cma, cxl-host]
+        enum: [blade, cxl-host]
 
   schemas:
     collection:
@@ -1671,4 +1671,4 @@ components:
           type: integer
         type:
           type: string
-          enum: [cma, cxl-host]
+          enum: [blade, cxl-host]

--- a/api/cfm-openapi.yaml
+++ b/api/cfm-openapi.yaml
@@ -49,6 +49,34 @@ paths:
               schema:
                 $ref: "#/components/schemas/serviceInformation"
 
+  /cfm/v1/discover:
+    get:
+      description: Discover devices on the network.
+      operationId: discoverDevices
+      parameters:
+        - name: type
+          in: query
+          description: Filter devices by type (either 'cma' or 'cxl-host')
+          required: true
+          schema:
+            type: string
+            enum: [cma, cxl-host]
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/device'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/statusMessage'
+
   # Memory Appliances
   /cfm/v1/appliances:
     get:
@@ -1630,3 +1658,15 @@ components:
         description:
           type: string
           description: The description of service(s) offered by the URI
+    device:
+      type: object
+      properties:
+        name:
+          type: string
+        address:
+          type: string
+        port:
+          type: integer
+        type:
+          type: string
+

--- a/api/cfm-openapi.yaml
+++ b/api/cfm-openapi.yaml
@@ -54,13 +54,7 @@ paths:
       description: Discover devices on the network.
       operationId: discoverDevices
       parameters:
-        - name: type
-          in: query
-          description: Filter devices by type (either 'cma' or 'cxl-host')
-          required: true
-          schema:
-            type: string
-            enum: [cma, cxl-host]
+        - $ref: "#/components/parameters/deviceType"
       responses:
         "200":
           description: OK
@@ -69,7 +63,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/device'
+                  $ref: '#/components/schemas/discoveredDevice'
         "500":
           description: Internal Server Error
           content:
@@ -1246,6 +1240,14 @@ components:
       required: true
       schema:
         $ref: "#/components/schemas/id"
+    deviceType:
+      description: Filter devices by type (either 'cma' or 'cxl-host')
+      name: deviceType
+      in: query
+      required: true
+      schema:
+        type: string
+        enum: [cma, cxl-host]
 
   schemas:
     collection:
@@ -1658,7 +1660,7 @@ components:
         description:
           type: string
           description: The description of service(s) offered by the URI
-    device:
+    discoveredDevice:
       type: object
       properties:
         name:
@@ -1669,4 +1671,4 @@ components:
           type: integer
         type:
           type: string
-
+          enum: [cma, cxl-host]

--- a/pkg/api/api_default_service.go
+++ b/pkg/api/api_default_service.go
@@ -1182,8 +1182,8 @@ type Device struct {
 }
 
 // DiscoverDevices -
-func (cfm *CfmApiService) DiscoverDevices(ctx context.Context, type_ string) (openapi.ImplResponse, error) {
-	if type_ != "cma" && type_ != "cxl-host" {
+func (cfm *CfmApiService) DiscoverDevices(ctx context.Context, deviceType string) (openapi.ImplResponse, error) {
+	if deviceType != "cma" && deviceType != "cxl-host" {
 		err := common.RequestError{
 			StatusCode: http.StatusBadRequest,
 			Err:        fmt.Errorf("invalid type parameter"),
@@ -1243,13 +1243,13 @@ func (cfm *CfmApiService) DiscoverDevices(ctx context.Context, type_ string) (op
 			resolvedService, err := server.ResolveService(service.Interface, service.Protocol, service.Name,
 				service.Type, service.Domain, avahi.ProtoInet, 0)
 			if err == nil {
-				// filter the servers by type_
-				if strings.Contains(string(resolvedService.Txt[0]), type_) {
+				// filter the servers by deviceType
+				if strings.Contains(string(resolvedService.Txt[0]), deviceType) {
 					currentDevice := Device{
 						Hostname: resolvedService.Host,
 						Address:  resolvedService.Address,
 						Port:     int(resolvedService.Port),
-						Type:     type_,
+						Type:     deviceType,
 					}
 					devices = append(devices, currentDevice)
 				}

--- a/pkg/api/api_default_service.go
+++ b/pkg/api/api_default_service.go
@@ -1487,10 +1487,10 @@ func (cfm *CfmApiService) DiscoverDevices(ctx context.Context, deviceType string
 				// filter the servers by deviceType
 				if strings.Contains(string(resolvedService.Txt[0]), deviceType) {
 					currentDevice := &openapi.DiscoveredDevice{
-						Name: resolvedService.Host,
-						Address:  resolvedService.Address,
-						Port:     int32(resolvedService.Port),
-						Type:     originDeviceType,
+						Name:    resolvedService.Host,
+						Address: resolvedService.Address,
+						Port:    int32(resolvedService.Port),
+						Type:    originDeviceType,
 					}
 					devices = append(devices, currentDevice)
 				}

--- a/pkg/api/api_default_service.go
+++ b/pkg/api/api_default_service.go
@@ -1425,12 +1425,18 @@ type Device struct {
 
 // DiscoverDevices -
 func (cfm *CfmApiService) DiscoverDevices(ctx context.Context, deviceType string) (openapi.ImplResponse, error) {
-	if deviceType != "cma" && deviceType != "cxl-host" {
+	if deviceType != "blade" && deviceType != "cxl-host" {
 		err := common.RequestError{
 			StatusCode: http.StatusBadRequest,
 			Err:        fmt.Errorf("invalid type parameter"),
 		}
 		return formatErrorResp(ctx, &err)
+	}
+
+	// Save the input deviceType to originDeviceType and change the deviceType to match service.txt
+	originDeviceType := deviceType
+	if deviceType == "blade" {
+		deviceType = "cma"
 	}
 
 	conn, err := dbus.SystemBus()
@@ -1491,7 +1497,7 @@ func (cfm *CfmApiService) DiscoverDevices(ctx context.Context, deviceType string
 						Hostname: resolvedService.Host,
 						Address:  resolvedService.Address,
 						Port:     int(resolvedService.Port),
-						Type:     deviceType,
+						Type:     originDeviceType,
 					}
 					devices = append(devices, currentDevice)
 				}

--- a/pkg/api/api_default_service.go
+++ b/pkg/api/api_default_service.go
@@ -1416,13 +1416,6 @@ func (cfm *CfmApiService) RootGet(ctx context.Context) (openapi.ImplResponse, er
 	return openapi.Response(http.StatusOK, response), nil
 }
 
-type Device struct {
-	Hostname string `json:"hostname"`
-	Address  string `json:"address"`
-	Port     int    `json:"port"`
-	Type     string `json:"type"`
-}
-
 // DiscoverDevices -
 func (cfm *CfmApiService) DiscoverDevices(ctx context.Context, deviceType string) (openapi.ImplResponse, error) {
 	if deviceType != "blade" && deviceType != "cxl-host" {
@@ -1464,7 +1457,7 @@ func (cfm *CfmApiService) DiscoverDevices(ctx context.Context, deviceType string
 		})
 	}
 
-	var devices []Device
+	var devices []*openapi.DiscoveredDevice
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -1493,10 +1486,10 @@ func (cfm *CfmApiService) DiscoverDevices(ctx context.Context, deviceType string
 			if err == nil {
 				// filter the servers by deviceType
 				if strings.Contains(string(resolvedService.Txt[0]), deviceType) {
-					currentDevice := Device{
-						Hostname: resolvedService.Host,
+					currentDevice := &openapi.DiscoveredDevice{
+						Name: resolvedService.Host,
 						Address:  resolvedService.Address,
-						Port:     int(resolvedService.Port),
+						Port:     int32(resolvedService.Port),
 						Type:     originDeviceType,
 					}
 					devices = append(devices, currentDevice)


### PR DESCRIPTION
This feature allows cfm to discover the devices in the network by type (cma or cxl-host).

`dingm@juniper:~/CFM/cfm$ curl -s -X GET http://localhost:8080/cfm/v1/discover?deviceType=cxl-host | jq`

> [
>   {
>     "hostname": "mag-cfm-cxlhost1.local",
>     "address": "10.20.47.243",
>     "port": 8082,
>     "type": "cxl-host"
>   }
> ]

`dingm@juniper:~/CFM/cfm$ curl -s -X GET http://localhost:8080/cfm/v1/discover?deviceType=blade | jq`

> [
>   {
>     "hostname": "granite104.local",
>     "address": "10.20.44.71",
>     "port": 443,
>     "type": "cma"
>   },
>   {
>     "hostname": "granite7.local",
>     "address": "10.20.47.212",
>     "port": 443,
>     "type": "cma"
>   }
> ]