### PR TITLE
feat(service): add a consolidated get of memory resource block statuses

### DIFF
--- a/api/cfm-openapi.yaml
+++ b/api/cfm-openapi.yaml
@@ -1796,7 +1796,8 @@ components:
           type: integer
         type:
           type: string
-          enum: [blade, cxl-host]    bladesMemoryStatusCollection:
+          enum: [blade, cxl-host]
+    bladesMemoryStatusCollection:
       description: Collection for blade memory status updates
       type: object
       required: [statusCount, memoryStatuses]

--- a/api/cfm-openapi.yaml
+++ b/api/cfm-openapi.yaml
@@ -1803,7 +1803,7 @@ components:
         id:
           $ref: "#/components/schemas/id"
     bladesMemoryResourceStatusCollection:
-      description: Collection for blade port status updates
+      description: Collection for blade memory resource block status updates
       type: object
       required: [statusCount, resourceStatuses]
       properties:
@@ -1829,7 +1829,7 @@ components:
         compositionStatus:
           $ref: '#/components/schemas/memoryResourceBlockCompositionStatus'
     bladesStatusCollection:
-      description: Collection for blade port status updates
+      description: Collection for blade status updates
       type: object
       required: [statusCount, bladeStatus]
       properties:

--- a/api/cfm-openapi.yaml
+++ b/api/cfm-openapi.yaml
@@ -8,7 +8,7 @@ info:
   license:
     name: Apache-2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 1.6.8
+  version: 1.7.0
 
 servers:
 - url: http://localhost:8080/
@@ -387,6 +387,128 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/statusMessage'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/statusMessage'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/statusMessage"
+
+  # Single Blade Status
+  /cfm/v1/appliances/{applianceId}/blades/{bladeId}/status:
+    get:
+      summary: Get blade status
+      description: Retrieve the hardware status of a specific blade, including memory, ports and resources.
+      operationId: bladesGetStatus
+      parameters:
+      - $ref: "#/components/parameters/applianceId"
+      - $ref: "#/components/parameters/bladeId"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bladesStatusCollection'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/statusMessage'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/statusMessage"
+
+  # Single Blade Memory Chunk Status
+  /cfm/v1/appliances/{applianceId}/blades/{bladeId}/statusmemory:
+    get:
+      summary: Get blades memory chunk status
+      description: Retrieve the status of memory on a specific blade.
+      operationId: bladesGetMemoryStatus
+      parameters:
+      - $ref: "#/components/parameters/applianceId"
+      - $ref: "#/components/parameters/bladeId"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/bladesMemoryStatus'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/statusMessage'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/statusMessage"
+
+  # Single Blade Port Status
+  /cfm/v1/appliances/{applianceId}/blades/{bladeId}/statusports:
+    get:
+      summary: Get blades port status
+      description: Retrieve the status of ports on a specific blade.
+      operationId: bladesGetPortStatus
+      parameters:
+      - $ref: "#/components/parameters/applianceId"
+      - $ref: "#/components/parameters/bladeId"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/bladesPortStatus'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/statusMessage'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/statusMessage"
+
+  # Single Blade Memory Resource Status
+  /cfm/v1/appliances/{applianceId}/blades/{bladeId}/statusresources:
+    get:
+      summary: Get blades memory resource status
+      description: Retrieve the status of resources on a specific blade.
+      operationId: bladesGetResourceStatus
+      parameters:
+      - $ref: "#/components/parameters/applianceId"
+      - $ref: "#/components/parameters/bladeId"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/bladesResourceStatus'
         "404":
           description: Not Found
           content:
@@ -1425,26 +1547,29 @@ components:
           $ref: "#/components/schemas/mebibytes"
         remoteMemoryMiB:
           $ref: "#/components/schemas/mebibytes"
+    memoryResourceBlockCompositionStatus:
+      description: Composition status information for the memory resource block
+      type: object
+      required: [compositionState]
+      properties:
+        compositionState:
+          type: string
+          description: The current state of the resource block from a composition perspective
+        maxCompositions:
+          type: integer
+          description: The maximum number of compositions in which this resource block can participate simultaneously
+        numberOfCompositions:
+          type: integer
+          description: The number of compositions in which this resource block is currently participating
     memoryResourceBlock:
       type: object
-      required: [id,compositionStatus,channelId,channelResourceIndex]
+      required: [id, compositionStatus, channelId, channelResourceIndex]
       properties:
         id:
           type: string
           description: The id of this resource
         compositionStatus:
-          type: object
-          required: [compositionState]
-          properties:
-            compositionState:
-              type: string
-              description: The current state of the resource block from a composition perspective
-            maxCompositions:
-              type: integer
-              description: The maximum number of compositions in which this resource block can participate simultaneously
-            numberOfCompositions:
-              type: integer
-              description: The number of compositions in which this resource block is currently participating
+          $ref: '#/components/schemas/memoryResourceBlockCompositionStatus'
         capacityMiB:
           type: integer
           description: The number of compositions in which this resource block is currently participating
@@ -1630,3 +1755,106 @@ components:
         description:
           type: string
           description: The description of service(s) offered by the URI
+    bladesMemoryStatusCollection:
+      description: Collection for blade memory status updates
+      type: object
+      required: [statusCount, memoryStatuses]
+      properties:
+        statusCount:
+          type: integer
+          minimum: 0
+          maximum: 10000
+        memoryStatuses:
+          type: array
+          minItems: 0
+          maxItems: 10000
+          items:
+            $ref: "#/components/schemas/bladesMemoryStatus"
+    bladesMemoryStatus:
+      type: object
+      description: Status of a single memory chunk
+      required: [uri, id]
+      properties:
+        uri:
+          $ref: "#/components/schemas/uri"
+        id:
+          $ref: "#/components/schemas/id"
+    bladesPortStatusCollection:
+      description: Collection for blade port status updates
+      type: object
+      required: [statusCount, portStatuses]
+      properties:
+        statusCount:
+          type: integer
+          minimum: 0
+          maximum: 10000
+        portStatuses:
+          type: array
+          minItems: 0
+          maxItems: 10000
+          items:
+            $ref: "#/components/schemas/bladesPortStatus"
+    bladesPortStatus:
+      type: object
+      description: Status of a single port
+      properties:
+        uri:
+          $ref: "#/components/schemas/uri"
+        id:
+          $ref: "#/components/schemas/id"
+    bladesMemoryResourceStatusCollection:
+      description: Collection for blade port status updates
+      type: object
+      required: [statusCount, resourceStatuses]
+      properties:
+        statusCount:
+          type: integer
+          minimum: 0
+          maximum: 10000
+        resourceStatuses:
+          type: array
+          minItems: 0
+          maxItems: 10000
+          items:
+            $ref: "#/components/schemas/bladesResourceStatus"
+    bladesResourceStatus:
+      type: object
+      description: Status of a single memory resource block
+      required: [uri, id, compositionStatus]
+      properties:
+        uri:
+          $ref: "#/components/schemas/uri"
+        id:
+          $ref: "#/components/schemas/id"
+        compositionStatus:
+          $ref: '#/components/schemas/memoryResourceBlockCompositionStatus'
+    bladesStatusCollection:
+      description: Collection for blade port status updates
+      type: object
+      required: [statusCount, bladeStatus]
+      properties:
+        statusCount:
+          type: integer
+          minimum: 0
+          maximum: 10000
+        bladeStatus:
+          type: array
+          minItems: 0
+          maxItems: 10000
+          items:
+            $ref: "#/components/schemas/bladeStatus"
+    bladeStatus:
+      type: object
+      description: Status of a single blade
+      required: [uri, id, memoryStatus, portStatus, resourceStatus]
+      properties:
+        uri:
+          $ref: "#/components/schemas/uri"
+        id:
+          $ref: "#/components/schemas/id"
+        memoryStatus:
+          $ref: '#/components/schemas/bladesMemoryStatusCollection'
+        portStatus:
+          $ref: '#/components/schemas/bladesPortStatusCollection'
+        resourceStatus:
+          $ref: '#/components/schemas/bladesMemoryResourceStatusCollection'

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -36,7 +36,7 @@ docker logs --follow <container-name>
 docker restart <container-name>
 ```
 
-## Excute CLI tool
+## Execute CLI tool
 
 The user can interact with the running cfm docker container (running cfm-service) to utilize the cli tool.
 

--- a/pkg/api/api_default_service.go
+++ b/pkg/api/api_default_service.go
@@ -12,6 +12,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"sort"
@@ -501,6 +502,23 @@ func (cfm *CfmApiService) BladesGetById(ctx context.Context, applianceId string,
 	return openapi.Response(http.StatusOK, b), nil
 }
 
+// BladesGetMemoryStatus - Get blades memory chunk status
+func (cfm *CfmApiService) BladesGetMemoryStatus(ctx context.Context, applianceId string, bladeId string) (openapi.ImplResponse, error) {
+	// TODO - update BladesGetMemoryStatus with the required logic for this service method.
+	// Add api_default_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, []BladesMemoryStatus{}) or use other options such as http.Ok ...
+	// return Response(200, []BladesMemoryStatus{}), nil
+
+	// TODO: Uncomment the next line to return response Response(404, StatusMessage{}) or use other options such as http.Ok ...
+	// return Response(404, StatusMessage{}), nil
+
+	// TODO: Uncomment the next line to return response Response(500, StatusMessage{}) or use other options such as http.Ok ...
+	// return Response(500, StatusMessage{}), nil
+
+	return openapi.Response(http.StatusNotImplemented, nil), errors.New("BladesGetMemoryStatus method not implemented")
+}
+
 // BladesGetMemory -
 func (cfm *CfmApiService) BladesGetMemory(ctx context.Context, applianceId string, bladeId string) (openapi.ImplResponse, error) {
 	mu.Lock()
@@ -607,6 +625,23 @@ func (cfm *CfmApiService) BladesGetPortById(ctx context.Context, applianceId str
 	} else {
 		return openapi.Response(http.StatusOK, openapi.PortInformation{}), nil
 	}
+}
+
+// BladesGetPortStatus - Get blades port status
+func (cfm *CfmApiService) BladesGetPortStatus(ctx context.Context, applianceId string, bladeId string) (openapi.ImplResponse, error) {
+	// TODO - update BladesGetPortStatus with the required logic for this service method.
+	// Add api_default_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, []BladesPortStatus{}) or use other options such as http.Ok ...
+	// return Response(200, []BladesPortStatus{}), nil
+
+	// TODO: Uncomment the next line to return response Response(404, StatusMessage{}) or use other options such as http.Ok ...
+	// return Response(404, StatusMessage{}), nil
+
+	// TODO: Uncomment the next line to return response Response(500, StatusMessage{}) or use other options such as http.Ok ...
+	// return Response(500, StatusMessage{}), nil
+
+	return openapi.Response(http.StatusNotImplemented, nil), errors.New("BladesGetPortStatus method not implemented")
 }
 
 // BladesGetPorts -
@@ -745,6 +780,32 @@ func (cfm *CfmApiService) BladesGetResourceById(ctx context.Context, applianceId
 	}
 }
 
+// BladesGetResourceStatus - Get blades memory resource status
+func (cfm *CfmApiService) BladesGetResourceStatus(ctx context.Context, applianceId string, bladeId string) (openapi.ImplResponse, error) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	logger := klog.FromContext(ctx)
+	logger.V(4).Info("###### BladesGetResourceStatus: ", "applianceId", applianceId, "bladeId", bladeId)
+
+	appliance, err := manager.GetApplianceById(ctx, applianceId)
+	if err != nil {
+		return formatErrorResp(ctx, err.(*common.RequestError))
+	}
+
+	blade, err := appliance.GetBladeById(ctx, bladeId)
+	if err != nil {
+		return formatErrorResp(ctx, err.(*common.RequestError))
+	}
+
+	collection, err := blade.GetResourceStatusesBackend(ctx)
+	if err != nil {
+		return formatErrorResp(ctx, err.(*common.RequestError))
+	}
+
+	return openapi.Response(http.StatusOK, collection), nil
+}
+
 // BladesGetResources -
 func (cfm *CfmApiService) BladesGetResources(ctx context.Context, applianceId string, bladeId string) (openapi.ImplResponse, error) {
 	mu.Lock()
@@ -779,6 +840,23 @@ func (cfm *CfmApiService) BladesGetResources(ctx context.Context, applianceId st
 	}
 
 	return openapi.Response(http.StatusOK, response), nil
+}
+
+// BladesGetStatus - Get blade status
+func (cfm *CfmApiService) BladesGetStatus(ctx context.Context, applianceId string, bladeId string) (openapi.ImplResponse, error) {
+	// TODO - update BladesGetStatus with the required logic for this service method.
+	// Add api_default_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
+
+	// TODO: Uncomment the next line to return response Response(200, BladesStatus{}) or use other options such as http.Ok ...
+	// return Response(200, BladesStatus{}), nil
+
+	// TODO: Uncomment the next line to return response Response(404, StatusMessage{}) or use other options such as http.Ok ...
+	// return Response(404, StatusMessage{}), nil
+
+	// TODO: Uncomment the next line to return response Response(500, StatusMessage{}) or use other options such as http.Ok ...
+	// return Response(500, StatusMessage{}), nil
+
+	return openapi.Response(http.StatusNotImplemented, nil), errors.New("BladesGetStatus method not implemented")
 }
 
 // BladesPost -

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -11,6 +11,7 @@ type BackendOperations interface {
 	CreateSession(context.Context, *ConfigurationSettings, *CreateSessionRequest) (*CreateSessionResponse, error)
 	DeleteSession(context.Context, *ConfigurationSettings, *DeleteSessionRequest) (*DeleteSessionResponse, error)
 	GetMemoryResourceBlocks(context.Context, *ConfigurationSettings, *MemoryResourceBlocksRequest) (*MemoryResourceBlocksResponse, error)
+	GetMemoryResourceBlockStatuses(ctx context.Context, settings *ConfigurationSettings, req *MemoryResourceBlockStatusesRequest) (*MemoryResourceBlockStatusesResponse, error)
 	GetMemoryResourceBlockById(context.Context, *ConfigurationSettings, *MemoryResourceBlockByIdRequest) (*MemoryResourceBlockByIdResponse, error)
 	GetPorts(context.Context, *ConfigurationSettings, *GetPortsRequest) (*GetPortsResponse, error)
 	GetHostPortPcieDevices(ctx context.Context, settings *ConfigurationSettings, req *GetPortsRequest) (*GetPortsResponse, error)

--- a/pkg/backend/httpfish.go
+++ b/pkg/backend/httpfish.go
@@ -1122,10 +1122,10 @@ func (service *httpfishService) GetMemoryResourceBlocks(ctx context.Context, set
 	return &MemoryResourceBlocksResponse{MemoryResources: memoryResources, Status: "Success"}, nil
 }
 
-// GetMemoryResourceBlocks: Request Memory Resource Block information from the backends
-// For backward compatibility, in the response:
+// GetMemoryResourceBlockStatuses: Request Memory Resource Block statuses from the backends
+// For BMC backward compatibility, in the response:
 //
-//	If CompositionStatuses == nil ==> BMC code does NOT return statuses
+//	If CompositionStatuses == nil ==> BMC code does NOT return statuses  <--deprecated in BMC firmware
 //	If CompositionStatuses != nil ==> BMC code DOES return statuses
 func (service *httpfishService) GetMemoryResourceBlockStatuses(ctx context.Context, settings *ConfigurationSettings, req *MemoryResourceBlockStatusesRequest) (*MemoryResourceBlockStatusesResponse, error) {
 	logger := klog.FromContext(ctx)

--- a/pkg/backend/httpfish.go
+++ b/pkg/backend/httpfish.go
@@ -1680,25 +1680,7 @@ func (service *httpfishService) GetMemoryById(ctx context.Context, setting *Conf
 
 	if strings.Contains(path, "CXL") { // host cxl memory
 		memoryRegion.Type = MemoryType(MEMORYTYPE_MEMORY_TYPE_CXL)
-		// // Check if performance metric is reported
-		// oemField, _ := response.valueFromJSON("Oem")
-		// if oemField != nil {
-		// Example partial redfish response showing Oem-Seagate format:
-		// 	/*     "Oem": {
-		// 		  	"Seagate": {
-		// 	 		"Bandwidth": "8.34 GiB/s",
-		// 	 		"Latency": "514 ns"
-		// 				}
-		// 			},
-		// 	*/
-		// 	bwStr := oemField.(map[string]interface{})["Seagate"].(map[string]interface{})["Bandwidth"].(string)
-		// 	bwFloat, _ := strconv.ParseFloat(strings.Split(bwStr, " ")[0], 64)
-		// 	memoryRegion.Bandwidth = int32(bwFloat)
-		// 	latStr := oemField.(map[string]interface{})["Seagate"].(map[string]interface{})["Latency"].(string)
-		// 	latInt64, _ := strconv.ParseInt(strings.Split(latStr, " ")[0], 10, 64)
-		// 	memoryRegion.Latency = int32(latInt64)
-		// }
-
+		// Check if performance metric is reported
 		seagateOem := extractSeagateOemMap(ctx, response)
 		if seagateOem != nil {
 			// Extract performance metrics

--- a/pkg/backend/ops.go
+++ b/pkg/backend/ops.go
@@ -78,14 +78,6 @@ type UnassignMemoryResponse struct {
 	Status string // The status of the request
 }
 
-type MemoryResourceBlocksRequest struct {
-}
-
-type MemoryResourceBlocksResponse struct {
-	MemoryResources []string // Array to hold ids of memory resources, get from memory appliance
-	Status          string   // The status of the request
-}
-
 type GetPortsRequest struct {
 }
 
@@ -154,10 +146,6 @@ type GetMemoryDeviceDetailsResponse struct {
 	Status        string                  // The status of the request
 }
 
-type MemoryResourceBlockByIdRequest struct {
-	ResourceId string // Resource ID for a particular memory resource, for example, resource01
-}
-
 type ResourceState int32
 
 const (
@@ -193,8 +181,8 @@ type MemoryResourceBlockCompositionStatus struct {
 type MemoryResourceBlock struct {
 	Id                 string // The id of this resource
 	CompositionStatus  MemoryResourceBlockCompositionStatus
-	CapacityMiB        int32  // The number of compositions in which this resource block is currently participating
-	DataWidthBits      int32  // The number of compositions in which this resource block is currently participating
+	CapacityMiB        int32  // Memory capacity of this resource block
+	DataWidthBits      int32  //
 	MemoryType         string // The type of memory device
 	MemoryDeviceType   string // Type details of the memory device
 	Manufacturer       string // The memory device manufacturer
@@ -204,6 +192,26 @@ type MemoryResourceBlock struct {
 	RankCount          int32  // Number of ranks available in the memory device
 	ChannelId          int32  // The id of the hardware channel associated with this resource
 	ChannelResourceIdx int32  // The index for this single resource within the given channel (designated by "ChannelId")
+}
+
+type MemoryResourceBlocksRequest struct {
+}
+
+type MemoryResourceBlocksResponse struct {
+	MemoryResources []string // Array to hold ids of memory resources, get from memory appliance
+	Status          string   // The status of the request
+}
+
+type MemoryResourceBlockStatusesRequest struct {
+}
+
+type MemoryResourceBlockStatusesResponse struct {
+	CompositionStatuses map[string]MemoryResourceBlockCompositionStatus // Array to memory resource block composition statuses
+	Status              string                                          // The status of the request
+}
+
+type MemoryResourceBlockByIdRequest struct {
+	ResourceId string // Resource ID for a particular memory resource, for example, resource01
 }
 
 type MemoryResourceBlockByIdResponse struct {

--- a/pkg/manager/blade.go
+++ b/pkg/manager/blade.go
@@ -15,6 +15,7 @@ import (
 	"cfm/pkg/common/datastore"
 	"cfm/pkg/openapi"
 
+	"github.com/facette/natsort"
 	"k8s.io/klog/v2"
 )
 
@@ -421,7 +422,7 @@ func (b *Blade) GetMemoryById(ctx context.Context, memoryId string) (*BladeMemor
 	logger.V(4).Info(">>>>>> GetMemoryById: ", "memoryId", memoryId, "bladeId", b.Id, "applianceId", b.ApplianceId)
 
 	if !b.IsOnline(ctx) {
-		// If blade offline, not an error.  Just no information to return.
+		// If blade not online, not an error.  Just no information to return.
 		return nil, nil
 	}
 
@@ -442,7 +443,7 @@ func (b *Blade) GetMemory(ctx context.Context) map[string]*BladeMemory {
 	logger.V(4).Info(">>>>>> GetMemory: ", "bladeId", b.Id, "applianceId", b.ApplianceId)
 
 	if !b.IsOnline(ctx) {
-		// If blade offline, not an error.  Just no information to return.
+		// If blade not online, not an error.  Just no information to return.
 		return make(map[string]*BladeMemory)
 	}
 
@@ -459,7 +460,7 @@ func (b *Blade) GetMemoryBackend(ctx context.Context) ([]string, error) {
 	logger.V(4).Info(">>>>>> GetMemoryBackend: ", "bladeId", b.Id, "applianceId", b.ApplianceId)
 
 	if !b.IsOnline(ctx) {
-		// If blade offline, not an error.  Just no information to return.
+		// If blade not online, not an error.  Just no information to return.
 		return make([]string, 0), nil
 	}
 
@@ -489,7 +490,7 @@ func (b *Blade) GetPortById(ctx context.Context, portId string) (*CxlBladePort, 
 	logger.V(4).Info(">>>>>> GetPortById: ", "portId", portId, "bladeId", b.Id, "applianceId", b.ApplianceId)
 
 	if !b.IsOnline(ctx) {
-		// If blade offline, not an error.  Just no information to return.
+		// If blade not online, not an error.  Just no information to return.
 		return nil, nil
 	}
 
@@ -510,7 +511,7 @@ func (b *Blade) GetPorts(ctx context.Context) map[string]*CxlBladePort {
 	logger.V(4).Info(">>>>>> GetPorts: ", "bladeId", b.Id, "applianceId", b.ApplianceId)
 
 	if !b.IsOnline(ctx) {
-		// If blade offline, not an error.  Just no information to return.
+		// If blade not online, not an error.  Just no information to return.
 		return make(map[string]*CxlBladePort)
 	}
 
@@ -527,7 +528,7 @@ func (b *Blade) GetPortsBackend(ctx context.Context) ([]string, error) {
 	logger.V(4).Info(">>>>>> GetPortsBackend: ", "bladeId", b.Id, "applianceId", b.ApplianceId)
 
 	if !b.IsOnline(ctx) {
-		// If blade offline, not an error.  Just no information to return.
+		// If blade not online, not an error.  Just no information to return.
 		return make([]string, 0), nil
 	}
 
@@ -549,7 +550,7 @@ func (b *Blade) GetResourceById(ctx context.Context, resourceId string) (*BladeR
 	logger.V(4).Info(">>>>>> GetResourceById: ", "resourceId", resourceId, "bladeId", b.Id, "applianceId", b.ApplianceId)
 
 	if !b.IsOnline(ctx) {
-		// If blade offline, not an error.  Just no information to return.
+		// If blade not online, not an error.  Just no information to return.
 		return nil, nil
 	}
 
@@ -570,7 +571,7 @@ func (b *Blade) GetResources(ctx context.Context) map[string]*BladeResource {
 	logger.V(4).Info(">>>>>> GetResources: ", "bladeId", b.Id, "applianceId", b.ApplianceId)
 
 	if !b.IsOnline(ctx) {
-		// If blade offline, not an error.  Just no information to return.
+		// If blade not online, not an error.  Just no information to return.
 		return make(map[string]*BladeResource)
 	}
 
@@ -587,7 +588,7 @@ func (b *Blade) GetResourcesBackend(ctx context.Context) ([]string, error) {
 	logger.V(4).Info(">>>>>> GetResourcesBackend: ", "bladeId", b.Id, "applianceId", b.ApplianceId)
 
 	if !b.IsOnline(ctx) {
-		// If blade offline, not an error.  Just no information to return.
+		// If blade not online, not an error.  Just no information to return.
 		return make([]string, 0), nil
 	}
 
@@ -602,6 +603,69 @@ func (b *Blade) GetResourcesBackend(ctx context.Context) ([]string, error) {
 	logger.V(2).Info("success: get resources(backend)", "resourceIds", response.MemoryResources, "bladeId", b.Id, "applianceId", b.ApplianceId)
 
 	return response.MemoryResources, nil
+}
+
+// GetResourcesBackend - Returns slice of hardware resource id's
+func (b *Blade) GetResourceStatusesBackend(ctx context.Context) (*openapi.BladesMemoryResourceStatusCollection, error) {
+	logger := klog.FromContext(ctx)
+	logger.V(4).Info(">>>>>> GetResourceStatusesBackend: ", "bladeId", b.Id, "applianceId", b.ApplianceId)
+
+	if !b.IsOnline(ctx) {
+		// If blade not online, not an error.  Just no information to return.
+		return &openapi.BladesMemoryResourceStatusCollection{StatusCount: 0, ResourceStatuses: make([]openapi.BladesResourceStatus, 0)}, nil
+	}
+
+	req := backend.MemoryResourceBlockStatusesRequest{}
+	response, err := b.backendOps.GetMemoryResourceBlockStatuses(ctx, &backend.ConfigurationSettings{}, &req)
+	if err != nil || response == nil {
+		newErr := fmt.Errorf("get resource statuses (backend) [%s] failure on blade [%s]: %w", b.backendOps.GetBackendInfo(ctx).BackendName, b.Id, err)
+		logger.Error(newErr, "failure: get resource statuses(backend)")
+		return nil, &common.RequestError{StatusCode: common.StatusBladeGetMemoryResourceBlocksFailure, Err: newErr}
+	}
+
+	// update manager's blade resource map
+	if response.CompositionStatuses != nil {
+		for resourceId, status := range response.CompositionStatuses {
+			resource, ok := b.Resources[resourceId]
+			if !ok {
+				logger.V(2).Info("warning: get resource statuses(backend): unrecognized resourceId detected", "resourceId", resourceId)
+				continue
+			}
+
+			resource.UpdateDetails(&status)
+		}
+	} else {
+		// For legacy BMC versions that didn't contain "OEM" and "Seagate" keys
+		logger.V(4).Info("get resource statuses(backend): no consolidated resources statuses found.  Returning last known statuses")
+	}
+
+	// build openapi collection from BladeResources
+	collection := openapi.BladesMemoryResourceStatusCollection{
+		StatusCount:      0,
+		ResourceStatuses: make([]openapi.BladesResourceStatus, 0, len(b.Resources)),
+	}
+
+	resourceIds := b.GetAllResourceIds(ctx)
+	natsort.Sort(resourceIds)
+
+	for _, resourceId := range resourceIds {
+		resource := b.Resources[resourceId]
+
+		resourceStatus := openapi.BladesResourceStatus{
+			Uri: GetCfmUriBladeResourceId(b.ApplianceId, b.Id, resource.Id),
+			Id:  resource.Id,
+			CompositionStatus: openapi.MemoryResourceBlockCompositionStatus{
+				CompositionState: resource.GetCompositionState(),
+			},
+		}
+
+		collection.StatusCount += 1
+		collection.ResourceStatuses = append(collection.ResourceStatuses, resourceStatus)
+	}
+
+	logger.V(2).Info("success: get resource statuses(backend)", "resource count", collection.StatusCount, "bladeId", b.Id, "applianceId", b.ApplianceId)
+
+	return &collection, nil
 }
 
 func (b *Blade) GetResourceTotals(ctx context.Context) (*ResponseResourceTotals, error) {

--- a/pkg/manager/resource.go
+++ b/pkg/manager/resource.go
@@ -147,6 +147,11 @@ func (r *BladeResource) InvalidateCache() {
 	r.cacheUpdated = false
 }
 
+// UpdateDetails - Update object with new backend information
+func (r *BladeResource) UpdateDetails(status *backend.MemoryResourceBlockCompositionStatus) {
+	r.details.CompositionStatus.CompositionState = status.CompositionState.String()
+}
+
 func (r *BladeResource) ValidateCache() {
 	r.cacheUpdated = true
 }


### PR DESCRIPTION
This changes gives the frontend client the ability to update the composition status of all blade memory resources blocks in a single call (BladesGetResourceStatus())

Statuses are returned as a collection:
```
type BladesMemoryResourceStatusCollection struct {
	StatusCount int32 `json:"statusCount"`
	ResourceStatuses []BladesResourceStatus `json:"resourceStatuses"`
}
```

with an array of statuses, with each element looking like:
```
type BladesResourceStatus struct {
	Uri string `json:"uri"`
	Id string `json:"id"`
	CompositionStatus MemoryResourceBlockCompositionStatus `json:"compositionStatus"`
}
``` 
and
```
type MemoryResourceBlockCompositionStatus struct {
	CompositionState string `json:"compositionState"`
	MaxCompositions int32 `json:"maxCompositions,omitempty"`
	NumberOfCompositions int32 `json:"numberOfCompositions,omitempty"`
}
```
This "status" struct can be expanded to include more information in the future.  Currently, though, it's just reporting composition state information.  
Curl output example:

![image](https://github.com/user-attachments/assets/4d9f6bbe-e001-479b-ba79-fe43c7625987)

When the blade is running legacy BMC code that does NOT provide a consolidated resource block status response, an empty collection is returned.  This will indicate to the client that they need to retrieve the status information one blade at a time via the `BladesGetResourceById` api. 
This behavior is for backward compatibility and is not the intended behavior going forward.

![image](https://github.com/user-attachments/assets/318fef21-29ce-4fd8-90f3-2ffdad96af0a)

Additional frontend API's were also added for being able to report similar status information for blade-memory, blade-ports and blades.  These have been left Not Implemented for now.
