### PR TITLE
fix(cxl-host): generate unique cxl host session id

### DIFF
--- a/cmd/cxl-host/service/cxl_host_service.go
+++ b/cmd/cxl-host/service/cxl_host_service.go
@@ -694,9 +694,13 @@ func (s *CxlHostApiService) RedfishV1SessionServiceSessionsPost(ctx context.Cont
 	}
 
 	// Create the session
-	session := accounts.CreateSession(ctx, *sessionV171Session.UserName, *sessionV171Session.Password)
-	if session == nil {
-		return redfishapi.Response(http.StatusUnauthorized, nil), errors.New("Invalid user credentials")
+	session, err := accounts.CreateSession(ctx, *sessionV171Session.UserName, *sessionV171Session.Password)
+	if err != nil {
+		if errors.Is(err, accounts.ErrInvalidCredentials) {
+			return redfishapi.Response(http.StatusUnauthorized, nil), err
+		} else if errors.Is(err, accounts.ErrGenerateSessionId) {
+			return redfishapi.Response(http.StatusInternalServerError, nil), err
+		}
 	}
 
 	resource := FillInSessionResource(session.Id, session, true)

--- a/pkg/accounts/sessions.go
+++ b/pkg/accounts/sessions.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"math/rand"
 	"strings"
 	"time"
@@ -17,11 +16,7 @@ import (
 
 const (
 	defaultSessionSeconds float64 = 60 * 30.0
-	maxSessionId          int     = math.MaxInt
 )
-
-// Track the last session id used, increment until a max is reached, then reset to 1
-var activeSessionId int = 0
 
 type SessionInformation struct {
 	Id       string
@@ -38,6 +33,7 @@ var sessions map[string]*SessionInformation
 func init() {
 	sessions = make(map[string]*SessionInformation)
 }
+
 var (
 	ErrInvalidCredentials = errors.New("invalid user credentials")
 	ErrGenerateSessionId  = errors.New("session id creation failure")


### PR DESCRIPTION
Changed the cxl-host internal redfish session id's from a simple incrementing integer to a 10 char random alpha-numeric string