### PR TITLE
feat(service): add the discovered devices and change the connection status to unavailable for failed devices

### DIFF
--- a/pkg/api/api_default_service.go
+++ b/pkg/api/api_default_service.go
@@ -796,7 +796,7 @@ func (cfm *CfmApiService) BladesPost(ctx context.Context, applianceId string, cr
 
 	appliance, err := manager.GetApplianceById(ctx, applianceId)
 	if err != nil {
-		return openapi.Response(http.StatusBadRequest, nil), err
+		return formatErrorResp(ctx, err.(*common.RequestError))
 	}
 
 	if len(appliance.Blades) == MAX_COUNT_BLADES {
@@ -804,17 +804,17 @@ func (cfm *CfmApiService) BladesPost(ctx context.Context, applianceId string, cr
 			StatusCode: common.StatusBladesExceedMaximum,
 			Err:        fmt.Errorf("cfm-service at maximum blade capacity (%d) for this appliance (%s)", MAX_COUNT_BLADES, applianceId),
 		}
-		return openapi.Response(http.StatusBadRequest, nil), &err
+		return formatErrorResp(ctx, &err)
 	}
 
 	blade, err := appliance.AddBlade(ctx, &credentials)
 	if err != nil {
-		return openapi.Response(http.StatusBadRequest, nil), err
+		return formatErrorResp(ctx, err.(*common.RequestError))
 	}
 
 	totals, err := blade.GetResourceTotals(ctx)
 	if err != nil {
-		return openapi.Response(http.StatusBadRequest, nil), err
+		return formatErrorResp(ctx, err.(*common.RequestError))
 	}
 
 	b := openapi.Blade{
@@ -1218,12 +1218,12 @@ func (cfm *CfmApiService) HostsPost(ctx context.Context, credentials openapi.Cre
 			StatusCode: common.StatusHostsExceedMaximum,
 			Err:        fmt.Errorf("cfm-service at maximum host capacity (%d)", MAX_COUNT_HOSTS),
 		}
-		return openapi.Response(http.StatusBadRequest, nil), &err
+		return formatErrorResp(ctx, &err)
 	}
 
 	host, err := manager.AddHost(ctx, &credentials)
 	if err != nil {
-		return openapi.Response(http.StatusBadRequest, nil), err
+		return formatErrorResp(ctx, err.(*common.RequestError))
 	}
 
 	h := openapi.Host{

--- a/pkg/api/api_default_service.go
+++ b/pkg/api/api_default_service.go
@@ -796,7 +796,7 @@ func (cfm *CfmApiService) BladesPost(ctx context.Context, applianceId string, cr
 
 	appliance, err := manager.GetApplianceById(ctx, applianceId)
 	if err != nil {
-		return formatErrorResp(ctx, err.(*common.RequestError))
+		return openapi.Response(http.StatusBadRequest, nil), err
 	}
 
 	if len(appliance.Blades) == MAX_COUNT_BLADES {
@@ -804,17 +804,17 @@ func (cfm *CfmApiService) BladesPost(ctx context.Context, applianceId string, cr
 			StatusCode: common.StatusBladesExceedMaximum,
 			Err:        fmt.Errorf("cfm-service at maximum blade capacity (%d) for this appliance (%s)", MAX_COUNT_BLADES, applianceId),
 		}
-		return formatErrorResp(ctx, &err)
+		return openapi.Response(http.StatusBadRequest, nil), &err
 	}
 
 	blade, err := appliance.AddBlade(ctx, &credentials)
 	if err != nil {
-		return formatErrorResp(ctx, err.(*common.RequestError))
+		return openapi.Response(http.StatusBadRequest, nil), err
 	}
 
 	totals, err := blade.GetResourceTotals(ctx)
 	if err != nil {
-		return formatErrorResp(ctx, err.(*common.RequestError))
+		return openapi.Response(http.StatusBadRequest, nil), err
 	}
 
 	b := openapi.Blade{
@@ -1218,12 +1218,12 @@ func (cfm *CfmApiService) HostsPost(ctx context.Context, credentials openapi.Cre
 			StatusCode: common.StatusHostsExceedMaximum,
 			Err:        fmt.Errorf("cfm-service at maximum host capacity (%d)", MAX_COUNT_HOSTS),
 		}
-		return formatErrorResp(ctx, &err)
+		return openapi.Response(http.StatusBadRequest, nil), &err
 	}
 
 	host, err := manager.AddHost(ctx, &credentials)
 	if err != nil {
-		return formatErrorResp(ctx, err.(*common.RequestError))
+		return openapi.Response(http.StatusBadRequest, nil), err
 	}
 
 	h := openapi.Host{

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -5,11 +5,11 @@ import "cfm/pkg/openapi"
 type ConnectionStatus string
 
 const (
-	ONLINE         ConnectionStatus = "online"
-	FOUND          ConnectionStatus = "found"
-	OFFLINE        ConnectionStatus = "offline"
+	ONLINE         ConnectionStatus = "online"      // avahi-found, found root service, created backend session, added to service map
+	UNAVAILABLE    ConnectionStatus = "unavailable" // avahi-found AND detect root service AND !created backend session AND !added to service map
+	FOUND          ConnectionStatus = "found"       // avahi-found AND detect root service
+	OFFLINE        ConnectionStatus = "offline"     // !avahi-found (after previously adding it)
 	NOT_APPLICABLE ConnectionStatus = "n\\a"
-	UNAVAILABLE        ConnectionStatus = "unavailable"
 )
 
 var DefaultApplianceCredentials = &openapi.Credentials{

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1,5 +1,7 @@
 package common
 
+import "cfm/pkg/openapi"
+
 type ConnectionStatus string
 
 const (
@@ -7,4 +9,35 @@ const (
 	FOUND          ConnectionStatus = "found"
 	OFFLINE        ConnectionStatus = "offline"
 	NOT_APPLICABLE ConnectionStatus = "n\\a"
+	UNAVAILABLE        ConnectionStatus = "unavailable"
 )
+
+var DefaultApplianceCredentials = &openapi.Credentials{
+	Username:  "root",
+	Password:  "0penBmc",
+	IpAddress: "127.0.0.1",
+	Port:      8443,
+	Insecure:  true,
+	Protocol:  "https",
+	CustomId:  "CMA_Discovered_Blades",
+}
+
+var DefaultBladeCredentials = &openapi.Credentials{
+	Username:  "root",
+	Password:  "0penBmc",
+	IpAddress: "127.0.0.1",
+	Port:      443,
+	Insecure:  true,
+	Protocol:  "https",
+	CustomId:  "Discoverd_Blade_",
+}
+
+var DefaultHostCredentials = &openapi.Credentials{
+	Username:  "admin",
+	Password:  "admin12345",
+	IpAddress: "127.0.0.1",
+	Port:      8082,
+	Insecure:  true,
+	Protocol:  "http",
+	CustomId:  "Discoverd_Host_",
+}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -7,7 +7,6 @@ type ConnectionStatus string
 const (
 	ONLINE         ConnectionStatus = "online"      // avahi-found, found root service, created backend session, added to service map
 	UNAVAILABLE    ConnectionStatus = "unavailable" // avahi-found AND detect root service AND !created backend session AND !added to service map
-	FOUND          ConnectionStatus = "found"       // avahi-found AND detect root service
 	OFFLINE        ConnectionStatus = "offline"     // !avahi-found (after previously adding it)
 	NOT_APPLICABLE ConnectionStatus = "n\\a"
 )

--- a/pkg/common/datastore/datastore.go
+++ b/pkg/common/datastore/datastore.go
@@ -58,6 +58,28 @@ func (c *DataStore) GetApplianceDatumById(applianceId string) (*ApplianceDatum, 
 	return datum, nil
 }
 
+// Verify if the blade exists using the ipAddress
+func (c *DataStore) GetBladeDatumByIp(IpAddress string) (*string, bool) {
+	for _, appliance := range c.ApplianceData {
+		for bladeId, blade := range appliance.BladeData {
+			if blade.Credentials.IpAddress == IpAddress {
+				return &bladeId, true
+			}
+		}
+	}
+	return nil, false
+}
+
+// Verify if the host exists using the ipAddress
+func (c *DataStore) GetHostDatumByIp(IpAddress string) (*string, bool) {
+	for hostId, host := range c.HostData {
+		if host.Credentials.IpAddress == IpAddress {
+			return &hostId, true
+		}
+	}
+	return nil, false
+}
+
 // GetHostDatumById: Retrieve a host datum from the data store
 func (c *DataStore) GetHostDatumById(hostId string) (*HostDatum, error) {
 	datum, exists := c.HostData[hostId]
@@ -109,28 +131,6 @@ func (a *ApplianceDatum) GetBladeDatumById(ctx context.Context, bladeId string) 
 	}
 
 	return blade, nil
-}
-
-// Verify if the blade exists using the ipAddress
-func (c *DataStore) GetBladeDatumByIp(IpAddress string) (*string, bool) {
-	for _, appliance := range c.ApplianceData {
-		for bladeId, blade := range appliance.BladeData {
-			if blade.Credentials.IpAddress == IpAddress {
-				return &bladeId, true
-			}
-		}
-	}
-	return nil, false
-}
-
-// Verify if the host exists using the ipAddress
-func (c *DataStore) GetHostDatumByIp(IpAddress string) (*string, bool) {
-	for hostId, host := range c.HostData {
-		if host.Credentials.IpAddress == IpAddress {
-			return &hostId, true
-		}
-	}
-	return nil, false
 }
 
 func (a *ApplianceDatum) SetConnectionStatus(status common.ConnectionStatus) {

--- a/pkg/common/datastore/datastore.go
+++ b/pkg/common/datastore/datastore.go
@@ -112,7 +112,7 @@ func (a *ApplianceDatum) GetBladeDatumById(ctx context.Context, bladeId string) 
 }
 
 // Verify if the blade exists using the ipAddress
-func (c *DataStore) CheckBladeExist(IpAddress string) (*string, bool) {
+func (c *DataStore) GetBladeDatumByIp(IpAddress string) (*string, bool) {
 	for _, appliance := range c.ApplianceData {
 		for bladeId, blade := range appliance.BladeData {
 			if blade.Credentials.IpAddress == IpAddress {
@@ -124,7 +124,7 @@ func (c *DataStore) CheckBladeExist(IpAddress string) (*string, bool) {
 }
 
 // Verify if the host exists using the ipAddress
-func (c *DataStore) CheckHostExist(IpAddress string) (*string, bool) {
+func (c *DataStore) GetHostDatumByIp(IpAddress string) (*string, bool) {
 	for hostId, host := range c.HostData {
 		if host.Credentials.IpAddress == IpAddress {
 			return &hostId, true
@@ -180,7 +180,7 @@ func ReloadDataStore(ctx context.Context, s openapi.DefaultAPIServicer, c *DataS
 	logger := klog.FromContext(ctx)
 
 	logger.V(2).Info("cfm-service: restoring saved appliances")
-	
+
 	for applianceId, applianceDatum := range c.ApplianceData {
 		_, err = s.AppliancesPost(ctx, *applianceDatum.Credentials)
 		if err != nil {

--- a/pkg/manager/appliance.go
+++ b/pkg/manager/appliance.go
@@ -378,7 +378,7 @@ func (a *Appliance) GetBladeById(ctx context.Context, bladeId string) (*Blade, e
 	if blade.CheckSync(ctx) {
 		logger.V(4).Info("initiating auto-resync check", "bladeId", bladeId, "applianceId", a.Id)
 		blade.UpdateConnectionStatusBackend(ctx)
-		if blade.Status == common.FOUND { // good power, bad session
+		if blade.Status == common.UNAVAILABLE { // good power, bad session
 			blade, err = a.ResyncBladeById(ctx, bladeId)
 			if err != nil {
 				newErr := fmt.Errorf("failed to resync blade by id [%s]: %w", bladeId, err)

--- a/pkg/manager/blade.go
+++ b/pkg/manager/blade.go
@@ -10,12 +10,12 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/klog/v2"
+
 	"cfm/pkg/backend"
 	"cfm/pkg/common"
 	"cfm/pkg/common/datastore"
 	"cfm/pkg/openapi"
-
-	"k8s.io/klog/v2"
 )
 
 const ID_PREFIX_BLADE_DFLT string = "blade"
@@ -663,7 +663,7 @@ func (b *Blade) UpdateConnectionStatusBackend(ctx context.Context) {
 		if status.FoundSession {
 			b.Status = common.ONLINE
 		} else {
-			b.Status = common.FOUND
+			b.Status = common.UNAVAILABLE
 		}
 	} else {
 		b.Status = common.OFFLINE

--- a/pkg/manager/host.go
+++ b/pkg/manager/host.go
@@ -8,12 +8,12 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/klog/v2"
+
 	"cfm/pkg/backend"
 	"cfm/pkg/common"
 	"cfm/pkg/common/datastore"
 	"cfm/pkg/openapi"
-
-	"k8s.io/klog/v2"
 )
 
 const ID_PREFIX_HOST_DFLT string = "host"
@@ -507,7 +507,7 @@ func (h *Host) UpdateConnectionStatusBackend(ctx context.Context) {
 		if status.FoundSession {
 			h.Status = common.ONLINE
 		} else {
-			h.Status = common.FOUND
+			h.Status = common.UNAVAILABLE
 		}
 	} else {
 		h.Status = common.OFFLINE

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -561,7 +561,7 @@ func GetHostById(ctx context.Context, hostId string) (*Host, error) {
 	if host.CheckSync(ctx) {
 		logger.V(4).Info("initiating auto-resync check", "hostId", hostId)
 		host.UpdateConnectionStatusBackend(ctx)
-		if host.Status == common.FOUND { // good power, bad session
+		if host.Status == common.UNAVAILABLE { // good power, bad session
 			host, err = ResyncHostById(ctx, hostId)
 			if err != nil {
 				newErr := fmt.Errorf("failed to resync host by id [%s]: %w", hostId, err)

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -331,6 +331,13 @@ func AddHost(ctx context.Context, c *openapi.Credentials) (*Host, error) {
 
 		newErr := fmt.Errorf("new host object creation failure: %w", err)
 		logger.Error(newErr, "failure: add host")
+
+		// Continue adding the failed host to the datastore, but update the connection status to offline
+		datastore.DStore().GetDataStore().AddHostDatum(c)
+		offlineHost, _ := datastore.DStore().GetDataStore().GetHostDatumById(c.CustomId)
+		offlineHost.ConnectionStatus = common.UNAVAILABLE
+		datastore.DStore().Store()
+
 		return nil, &common.RequestError{StatusCode: common.StatusManagerInitializationFailure, Err: newErr}
 	}
 

--- a/services/discovery.go
+++ b/services/discovery.go
@@ -40,7 +40,7 @@ func AddDiscoveredDevices(ctx context.Context, apiService openapi.DefaultAPIServ
 	}
 	applianceDatum, _ := datastore.DStore().GetDataStore().GetApplianceDatumById(common.DefaultApplianceCredentials.CustomId)
 	for _, bladeDevice := range bladeBodyBytes {
-		_, exist := data.CheckBladeExist(bladeDevice.Address)
+		_, exist := data.GetBladeDatumByIp(bladeDevice.Address)
 		if !exist {
 			newCredentials := *common.DefaultBladeCredentials
 			newCredentials.IpAddress = bladeDevice.Address
@@ -59,7 +59,7 @@ func AddDiscoveredDevices(ctx context.Context, apiService openapi.DefaultAPIServ
 		log.Fatalf("Response body is not []byte")
 	}
 	for _, hostDevice := range hostBodyBytes {
-		_, exist := data.CheckHostExist(hostDevice.Address)
+		_, exist := data.GetHostDatumByIp(hostDevice.Address)
 		if !exist {
 			newCredentials := *common.DefaultHostCredentials
 			newCredentials.IpAddress = hostDevice.Address

--- a/services/discovery.go
+++ b/services/discovery.go
@@ -1,0 +1,74 @@
+package services
+
+import (
+	"log"
+
+	"golang.org/x/net/context"
+
+	"cfm/pkg/common"
+	"cfm/pkg/common/datastore"
+	"cfm/pkg/openapi"
+)
+
+// discoverDevices function to call the DiscoverDevices API
+func DiscoverDevices(ctx context.Context, apiService openapi.DefaultAPIServicer, deviceType string) (openapi.ImplResponse, error) {
+	resp, err := apiService.DiscoverDevices(ctx, deviceType)
+	if err != nil {
+		log.Printf("Error discovering devices of type %s: %v", deviceType, err)
+		return resp, err
+	} else {
+		log.Printf("Discovered devices of type %s: %v", deviceType, resp)
+		return resp, nil
+	}
+}
+
+func AddDiscoveredDevices(ctx context.Context, apiService openapi.DefaultAPIServicer, blades openapi.ImplResponse, hosts openapi.ImplResponse) {
+	// Verify the existence of the default appliance; if it doesn't exist, add it
+	datastore.DStore().Restore()
+	data := datastore.DStore().GetDataStore()
+	_, err := datastore.DStore().GetDataStore().GetApplianceDatumById(common.DefaultApplianceCredentials.CustomId)
+	if err != nil {
+		datastore.DStore().GetDataStore().AddApplianceDatum(common.DefaultApplianceCredentials)
+		datastore.DStore().Store()
+	}
+
+	// Add blades
+	// Convert data type
+	bladeBodyBytes, ok := blades.Body.([]*openapi.DiscoveredDevice)
+	if !ok {
+		log.Fatalf("Response body is not []byte")
+	}
+	applianceDatum, _ := datastore.DStore().GetDataStore().GetApplianceDatumById(common.DefaultApplianceCredentials.CustomId)
+	for _, bladeDevice := range bladeBodyBytes {
+		_, exist := data.CheckBladeExist(bladeDevice.Address)
+		if !exist {
+			newCredentials := *common.DefaultBladeCredentials
+			newCredentials.IpAddress = bladeDevice.Address
+			//Assign the actual ipAddress to customId to ensure its uniqueness
+			newCredentials.CustomId = newCredentials.CustomId + bladeDevice.Address
+
+			applianceDatum.AddBladeDatum(&newCredentials)
+			datastore.DStore().Store()
+		}
+	}
+
+	// Add cxl-hosts
+	// Convert data type
+	hostBodyBytes, ok := hosts.Body.([]*openapi.DiscoveredDevice)
+	if !ok {
+		log.Fatalf("Response body is not []byte")
+	}
+	for _, hostDevice := range hostBodyBytes {
+		_, exist := data.CheckHostExist(hostDevice.Address)
+		if !exist {
+			newCredentials := *common.DefaultHostCredentials
+			newCredentials.IpAddress = hostDevice.Address
+			//Assign the actual ipAddress to customId to ensure its uniqueness
+			newCredentials.CustomId = newCredentials.CustomId + hostDevice.Address
+
+			datastore.DStore().GetDataStore().AddHostDatum(&newCredentials)
+			datastore.DStore().Store()
+		}
+
+	}
+}


### PR DESCRIPTION
Add the discovered devices and change the connection status to unavailable for failed devices at the beginning of the cfm-service run, Will change the display color for the unavailable devices in the following work in cfm-webui.
![image](https://github.com/user-attachments/assets/b23fd604-9ae5-4a7c-935c-3f4fdfd3fd6d)
![image](https://github.com/user-attachments/assets/51acb605-14ac-4e87-9457-83a8890a1270)


