### PR TITLE
fix(cli): consolidate and repair backend error handling

### DIFF
--- a/cli/pkg/serviceLib/serviceRequests/blades.go
+++ b/cli/pkg/serviceLib/serviceRequests/blades.go
@@ -122,7 +122,6 @@ func (r *ServiceRequestListBlades) Execute() (*serviceWrap.ApplianceBladeSummary
 
 	klog.V(4).InfoS(fmt.Sprintf("%T", *r), "ServiceTcp", fmt.Sprintf("%+v", *r.ServiceTcp))
 	klog.V(4).InfoS(fmt.Sprintf("%T", *r), "ApplianceId", fmt.Sprintf("%+v", *r.ApplianceId))
-	klog.V(4).InfoS(fmt.Sprintf("%T", *r), "BladeId", fmt.Sprintf("%+v", *r.BladeId))
 
 	serviceClient := serviceWrap.GetServiceClient(r.ServiceTcp.GetIp(), r.ServiceTcp.GetPort())
 

--- a/cli/pkg/serviceLib/serviceWrap/blade.go
+++ b/cli/pkg/serviceLib/serviceWrap/blade.go
@@ -4,7 +4,6 @@ package serviceWrap
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	service "cfm/pkg/client"
@@ -54,19 +53,12 @@ func AddBlade(client *service.APIClient, applianceId string, bladeCreds *service
 	request := client.DefaultAPI.BladesPost(context.Background(), applianceId)
 	request = request.Credentials(*bladeCreds)
 	blade, response, err := request.Execute()
+	if response != nil {
+		defer response.Body.Close() // Required by http lib implementation.
+	}
 	if err != nil {
-		// Decode the JSON response into a struct
-		var status service.StatusMessage
-		if err := json.NewDecoder(response.Body).Decode(&status); err != nil {
-			newErr := fmt.Errorf("failure: Execute(%T): err(%s), error decoding response JSON", request, err)
-			klog.V(4).Info(newErr)
-			return nil, newErr
-		}
-
-		newErr := fmt.Errorf("failure: Execute(%T): err(%s), uri(%s), details(%s), code(%d), message(%s)",
-			request, err, status.Uri, status.Details, status.Status.Code, status.Status.Message)
-		klog.V(4).Info(newErr)
-		return nil, newErr
+		newErr := handleServiceError(response, err)
+		return nil, fmt.Errorf("execute failure(%T): %w", request, newErr)
 	}
 
 	klog.V(3).InfoS("success: AddBlade", "bladeId", blade.GetId(), "applianceId", applianceId)
@@ -77,19 +69,12 @@ func AddBlade(client *service.APIClient, applianceId string, bladeCreds *service
 func DeleteBladeById(client *service.APIClient, applId, bladeId string) (*service.Blade, error) {
 	request := client.DefaultAPI.BladesDeleteById(context.Background(), applId, bladeId)
 	blade, response, err := request.Execute()
+	if response != nil {
+		defer response.Body.Close() // Required by http lib implementation.
+	}
 	if err != nil {
-		// Decode the JSON response into a struct
-		var status service.StatusMessage
-		if err := json.NewDecoder(response.Body).Decode(&status); err != nil {
-			newErr := fmt.Errorf("failure: Execute(%T): err(%s), error decoding response JSON", request, err)
-			klog.V(4).Info(newErr)
-			return nil, newErr
-		}
-
-		newErr := fmt.Errorf("failure: Execute(%T): err(%s), uri(%s), details(%s), code(%d), message(%s)",
-			request, err, status.Uri, status.Details, status.Status.Code, status.Status.Message)
-		klog.V(4).Info(newErr)
-		return nil, newErr
+		newErr := handleServiceError(response, err)
+		return nil, fmt.Errorf("execute failure(%T): %w", request, newErr)
 	}
 
 	klog.V(3).InfoS("success: DeleteBladeById", "applianceId", applId, "bladeID", blade.GetId())
@@ -103,19 +88,12 @@ func FindBladeById_SingleAppl(client *service.APIClient, applId, bladeId string)
 	request := client.DefaultAPI.BladesGetById(context.Background(), applId, bladeId)
 	//TODO: What does this api do when the blade is empty
 	blade, response, err := request.Execute()
+	if response != nil {
+		defer response.Body.Close() // Required by http lib implementation.
+	}
 	if err != nil {
-		// Decode the JSON response into a struct
-		var status service.StatusMessage
-		if err := json.NewDecoder(response.Body).Decode(&status); err != nil {
-			newErr := fmt.Errorf("failure: Execute(%T): err(%s), error decoding response JSON", request, err)
-			klog.V(4).Info(newErr)
-			return nil, newErr
-		}
-
-		newErr := fmt.Errorf("failure: Execute(%T): err(%s), uri(%s), details(%s), code(%d), message(%s)",
-			request, err, status.Uri, status.Details, status.Status.Code, status.Status.Message)
-		klog.V(4).Info(newErr)
-		return nil, newErr
+		newErr := handleServiceError(response, err)
+		return nil, fmt.Errorf("execute failure(%T): %w", request, newErr)
 	}
 
 	klog.V(3).InfoS("success: FindBladeById_SingleAppl", "applianceId", applId, "bladeId", blade.GetId())
@@ -130,19 +108,12 @@ func FindBladeById_AllAppls(client *service.APIClient, bladeId string) (*Applian
 	//Get all existing appliances
 	request := client.DefaultAPI.AppliancesGet(context.Background())
 	applColl, response, err := request.Execute()
+	if response != nil {
+		defer response.Body.Close() // Required by http lib implementation.
+	}
 	if err != nil {
-		// Decode the JSON response into a struct
-		var status service.StatusMessage
-		if err := json.NewDecoder(response.Body).Decode(&status); err != nil {
-			newErr := fmt.Errorf("failure: Execute(%T): err(%s), error decoding response JSON", request, err)
-			klog.V(4).Info(newErr)
-			return nil, newErr
-		}
-
-		newErr := fmt.Errorf("failure: Execute(%T): err(%s), uri(%s), details(%s), code(%d), message(%s)",
-			request, err, status.Uri, status.Details, status.Status.Code, status.Status.Message)
-		klog.V(4).Info(newErr)
-		return nil, newErr
+		newErr := handleServiceError(response, err)
+		return nil, fmt.Errorf("execute failure(%T): %w", request, newErr)
 	}
 
 	klog.V(4).InfoS("success: AppliancesGet", "applCount", applColl.GetMemberCount())
@@ -173,19 +144,12 @@ func GetAllBlades_SingleAppl(client *service.APIClient, applId string) (*[]*serv
 
 	request := client.DefaultAPI.BladesGet(context.Background(), applId)
 	bladeColl, response, err := request.Execute()
+	if response != nil {
+		defer response.Body.Close() // Required by http lib implementation.
+	}
 	if err != nil {
-		// Decode the JSON response into a struct
-		var status service.StatusMessage
-		if err := json.NewDecoder(response.Body).Decode(&status); err != nil {
-			newErr := fmt.Errorf("failure: Execute(%T): err(%s), error decoding response JSON", request, err)
-			klog.V(4).Info(newErr)
-			return nil, newErr
-		}
-
-		newErr := fmt.Errorf("failure: Execute(%T): err(%s), uri(%s), details(%s), code(%d), message(%s)",
-			request, err, status.Uri, status.Details, status.Status.Code, status.Status.Message)
-		klog.V(4).Info(newErr)
-		return nil, newErr
+		newErr := handleServiceError(response, err)
+		return nil, fmt.Errorf("execute failure(%T): %w", request, newErr)
 	}
 
 	klog.V(4).InfoS("success: BladesGet", "applianceId", applId, "bladeCount", bladeColl.GetMemberCount())
@@ -211,19 +175,12 @@ func GetAllBlades_AllAppls(client *service.APIClient) (*ApplianceBladeSummary, e
 	//Get all existing appliances
 	request := client.DefaultAPI.AppliancesGet(context.Background())
 	applColl, response, err := request.Execute()
+	if response != nil {
+		defer response.Body.Close() // Required by http lib implementation.
+	}
 	if err != nil {
-		// Decode the JSON response into a struct
-		var status service.StatusMessage
-		if err := json.NewDecoder(response.Body).Decode(&status); err != nil {
-			newErr := fmt.Errorf("failure: Execute(%T): err(%s), error decoding response JSON", request, err)
-			klog.V(4).Info(newErr)
-			return nil, newErr
-		}
-
-		newErr := fmt.Errorf("failure: Execute(%T): err(%s), uri(%s), details(%s), code(%d), message(%s)",
-			request, err, status.Uri, status.Details, status.Status.Code, status.Status.Message)
-		klog.V(4).Info(newErr)
-		return nil, newErr
+		newErr := handleServiceError(response, err)
+		return nil, fmt.Errorf("execute failure(%T): %w", request, newErr)
 	}
 
 	klog.V(4).InfoS("success: AppliancesGet", "applCount", applColl.GetMemberCount())
@@ -247,19 +204,12 @@ func RenameBladeById(client *service.APIClient, applId string, bladeId string, n
 	request := client.DefaultAPI.BladesUpdateById(context.Background(), applId, bladeId)
 	request = request.NewBladeId(newBladeId)
 	blade, response, err := request.Execute()
+	if response != nil {
+		defer response.Body.Close() // Required by http lib implementation.
+	}
 	if err != nil {
-		// Decode the JSON response into a struct
-		var status service.StatusMessage
-		if err := json.NewDecoder(response.Body).Decode(&status); err != nil {
-			newErr := fmt.Errorf("failure: Execute(%T): err(%s), error decoding response JSON", request, err)
-			klog.V(4).Info(newErr)
-			return nil, newErr
-		}
-
-		newErr := fmt.Errorf("failure: Execute(%T): err(%s), uri(%s), details(%s), code(%d), message(%s)",
-			request, err, status.Uri, status.Details, status.Status.Code, status.Status.Message)
-		klog.V(4).Info(newErr)
-		return nil, newErr
+		newErr := handleServiceError(response, err)
+		return nil, fmt.Errorf("execute failure(%T): %w", request, newErr)
 	}
 
 	klog.V(3).InfoS("success: RenameBladeById", "request", request)
@@ -270,19 +220,12 @@ func RenameBladeById(client *service.APIClient, applId string, bladeId string, n
 func ResyncBladeById(client *service.APIClient, applId, bladeId string) (*service.Blade, error) {
 	request := client.DefaultAPI.BladesResyncById(context.Background(), applId, bladeId)
 	blade, response, err := request.Execute()
+	if response != nil {
+		defer response.Body.Close() // Required by http lib implementation.
+	}
 	if err != nil {
-		// Decode the JSON response into a struct
-		var status service.StatusMessage
-		if err := json.NewDecoder(response.Body).Decode(&status); err != nil {
-			newErr := fmt.Errorf("failure: Execute(%T): err(%s), error decoding response JSON", request, err)
-			klog.V(4).Info(newErr)
-			return nil, newErr
-		}
-
-		newErr := fmt.Errorf("failure: Execute(%T): err(%s), uri(%s), details(%s), code(%d), message(%s)",
-			request, err, status.Uri, status.Details, status.Status.Code, status.Status.Message)
-		klog.V(4).Info(newErr)
-		return nil, newErr
+		newErr := handleServiceError(response, err)
+		return nil, fmt.Errorf("execute failure(%T): %w", request, newErr)
 	}
 
 	klog.V(3).InfoS("success: ResyncBladeById", "applianceId", applId, "bladeID", blade.GetId())

--- a/cli/pkg/serviceLib/serviceWrap/common.go
+++ b/cli/pkg/serviceLib/serviceWrap/common.go
@@ -3,13 +3,17 @@
 package serviceWrap
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
 	"net/netip"
 	"strings"
 
 	service "cfm/pkg/client"
 
 	"github.com/google/uuid"
+	"k8s.io/klog/v2"
 )
 
 func GetServiceClient(ip string, networkPort uint16) *service.APIClient {
@@ -133,4 +137,30 @@ func NewApplianceBladeKey(applId, bladeId string) *ApplianceBladeKey {
 		ApplianceId: applId,
 		BladeId:     bladeId,
 	}
+}
+
+func handleServiceError(response *http.Response, err error) error {
+	var status service.StatusMessage
+
+	if response == nil {
+		return fmt.Errorf("no response body to interrogate during error, just return the error: %s", err)
+	}
+
+	//Purposefully NOT using key\value pairing here for the "response object".
+	//  ErrorS() is interrogating the response object, in the "key" location, in such a way that it displays extra error information from within the response body that isn't visible using a basic string cast of the object.
+	//  Currently, unsure of another way to get at this info.
+	//  Note: After the json Decode() call just below, the extra error information is gone, so, must dump here.
+	//  So far, not normally needed.  Put on the verbosity flag so it's only visible when requested.
+	klog.V(4).ErrorS(errors.New(""), "failure: raw response dump: ", response)
+
+	decodeError := json.NewDecoder(response.Body).Decode(&status)
+	if decodeError != nil {
+		// code for when Decode of the service's StatusMessage type fails, which means it's another type of error (like http).
+		return fmt.Errorf("error decoding response JSON: %s: ", decodeError)
+	}
+
+	newErr := fmt.Errorf("failure: err(%s), uri(%s), details(%s), code(%d), message(%s)",
+		err, status.Uri, status.Details, status.Status.Code, status.Status.Message)
+
+	return fmt.Errorf("response error info: %s", newErr)
 }

--- a/cli/pkg/serviceLib/serviceWrap/memory-devices.go
+++ b/cli/pkg/serviceLib/serviceWrap/memory-devices.go
@@ -4,7 +4,6 @@ package serviceWrap
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	service "cfm/pkg/client"
@@ -57,19 +56,12 @@ func FindMemoryDeviceOnHost(client *service.APIClient, hostId, memoryDeviceId st
 
 	request := client.DefaultAPI.HostsGetMemoryDeviceById(context.Background(), hostId, memoryDeviceId)
 	memoryDevice, response, err := request.Execute()
+	if response != nil {
+		defer response.Body.Close() // Required by http lib implementation.
+	}
 	if err != nil {
-		// Decode the JSON response into a struct
-		var status service.StatusMessage
-		if err := json.NewDecoder(response.Body).Decode(&status); err != nil {
-			newErr := fmt.Errorf("failure: Execute(%T): err(%s), error decoding response JSON", request, err)
-			klog.V(4).Info(newErr)
-			return nil, newErr
-		}
-
-		newErr := fmt.Errorf("failure: Execute(%T): err(%s), uri(%s), details(%s), code(%d), message(%s)",
-			request, err, status.Uri, status.Details, status.Status.Code, status.Status.Message)
-		klog.V(4).Info(newErr)
-		return nil, newErr
+		newErr := handleServiceError(response, err)
+		return nil, fmt.Errorf("execute failure(%T): %w", request, newErr)
 	}
 
 	klog.V(3).InfoS("success: FindMemoryDeviceOnHost", "hostId", hostId, "memoryDeviceId", memoryDevice.GetId())
@@ -82,19 +74,13 @@ func GetAllMemoryDevicesForHost(client *service.APIClient, hostId string) (*[]*s
 
 	request := client.DefaultAPI.HostsGetMemoryDevices(context.Background(), hostId)
 	memoryDeviceColl, response, err := request.Execute()
+	if response != nil {
+		defer response.Body.Close() // Required by http lib implementation.
+	}
 	if err != nil {
-		// Decode the JSON response into a struct
-		var status service.StatusMessage
-		if err := json.NewDecoder(response.Body).Decode(&status); err != nil {
-			newErr := fmt.Errorf("failure: Execute(%T): err(%s), error decoding response JSON", request, err)
-			klog.V(4).Info(newErr)
-			return nil, newErr
-		}
-
-		newErr := fmt.Errorf("failure: Execute(%T): err(%s), uri(%s), details(%s), code(%d), message(%s)",
-			request, err, status.Uri, status.Details, status.Status.Code, status.Status.Message)
-		klog.V(4).Info(newErr)
-		// return nil, newErr
+		// newErr := handleServiceError(response, err)
+		// return nil, fmt.Errorf("execute failure(%T): %w", request, newErr)
+		handleServiceError(response, err)
 		return &memoryDevices, nil //TODO: Error here instead?
 	}
 
@@ -102,21 +88,15 @@ func GetAllMemoryDevicesForHost(client *service.APIClient, hostId string) (*[]*s
 
 	for _, member := range memoryDeviceColl.GetMembers() {
 		memoryDeviceId := ReadLastItemFromUri(member.GetUri())
-		request := client.DefaultAPI.HostsGetMemoryDeviceById(context.Background(), hostId, memoryDeviceId)
-		memoryDevice, response, err := request.Execute()
+		request2 := client.DefaultAPI.HostsGetMemoryDeviceById(context.Background(), hostId, memoryDeviceId)
+		memoryDevice, response2, err := request2.Execute()
+		if response2 != nil {
+			defer response2.Body.Close() // Required by http lib implementation.
+		}
 		if err != nil {
-			// Decode the JSON response into a struct
-			var status service.StatusMessage
-			if err := json.NewDecoder(response.Body).Decode(&status); err != nil {
-				newErr := fmt.Errorf("failure: Execute(%T): err(%s), error decoding response JSON", request, err)
-				klog.V(4).Info(newErr)
-				return nil, newErr
-			}
-
-			newErr := fmt.Errorf("failure: Execute(%T): err(%s), uri(%s), details(%s), code(%d), message(%s)",
-				request, err, status.Uri, status.Details, status.Status.Code, status.Status.Message)
-			klog.V(4).Info(newErr)
-			// return nil, newErr
+			// newErr := handleServiceError(response2, err)
+			// return nil, fmt.Errorf("execute failure(%T): %w", request2, newErr)
+			handleServiceError(response2, err)
 			continue //TODO: Error here instead?
 		}
 
@@ -134,19 +114,13 @@ func GetMemoryDevices_AllHosts(client *service.APIClient) (*HostMemoryDeviceSumm
 
 	request := client.DefaultAPI.HostsGet(context.Background())
 	hostColl, response, err := request.Execute()
+	if response != nil {
+		defer response.Body.Close() // Required by http lib implementation.
+	}
 	if err != nil {
-		// Decode the JSON response into a struct
-		var status service.StatusMessage
-		if err := json.NewDecoder(response.Body).Decode(&status); err != nil {
-			newErr := fmt.Errorf("failure: Execute(%T): err(%s), error decoding response JSON", request, err)
-			klog.V(4).Info(newErr)
-			return nil, newErr
-		}
-
-		newErr := fmt.Errorf("failure: Execute(%T): err(%s), uri(%s), details(%s), code(%d), message(%s)",
-			request, err, status.Uri, status.Details, status.Status.Code, status.Status.Message)
-		klog.V(4).Info(newErr)
-		// return nil, newErr
+		// newErr := handleServiceError(response, err)
+		// return nil, fmt.Errorf("execute failure(%T): %w", request, newErr)
+		handleServiceError(response, err)
 		return summary, nil //TODO: Error here instead?
 	}
 
@@ -170,19 +144,13 @@ func FindMemoryDevice_AllHosts(client *service.APIClient, memoryDeviceId string)
 
 	request := client.DefaultAPI.HostsGet(context.Background())
 	hostColl, response, err := request.Execute()
+	if response != nil {
+		defer response.Body.Close() // Required by http lib implementation.
+	}
 	if err != nil {
-		// Decode the JSON response into a struct
-		var status service.StatusMessage
-		if err := json.NewDecoder(response.Body).Decode(&status); err != nil {
-			newErr := fmt.Errorf("failure: Execute(%T): err(%s), error decoding response JSON", request, err)
-			klog.V(4).Info(newErr)
-			return nil, newErr
-		}
-
-		newErr := fmt.Errorf("failure: Execute(%T): err(%s), uri(%s), details(%s), code(%d), message(%s)",
-			request, err, status.Uri, status.Details, status.Status.Code, status.Status.Message)
-		klog.V(4).Info(newErr)
-		// return nil, newErr
+		// newErr := handleServiceError(response, err)
+		// return nil, fmt.Errorf("execute failure(%T): %w", request, newErr)
+		handleServiceError(response, err)
 		return summary, nil //TODO: Error here instead?
 	}
 


### PR DESCRIPTION
The same error handling code is copy-pasted all over the backend. Consolidate this code in 1 common error handler function so it's easier to update next time.
Then, fixed the code that's not handling non-cfm-service errors correctly.
Also, fixed potential memory leaks that come from NOT using "defer response.Body.Close()" after a calls into cfm-service client.