### PR TITLE
refactor(cli): command usage and example string generation refactor and update

### DIFF
--- a/cli/pkg/serviceLib/flags/examples.go
+++ b/cli/pkg/serviceLib/flags/examples.go
@@ -1,0 +1,326 @@
+// Copyright (c) 2024 Seagate Technology LLC and/or its Affiliates
+package flags
+
+import "fmt"
+
+// Family of getter functions to allow retrieval of consistent strings, for each option, when building the cobra.Command Example field string across multiple commands.
+
+func GetOptionExampleLhGroupServiceTcp() string {
+	return fmt.Sprintf("%s %s %s %s",
+		GetOptionExampleLhServiceIp(),
+		GetOptionExampleLhServicePort(),
+		GetOptionExampleLhServiceInsecure(),
+		GetOptionExampleLhServiceProtocol())
+}
+
+func GetOptionExampleLhServiceIp() string {
+	return fmt.Sprintf("--%s %s", SERVICE_NET_IP, SERVICE_NET_IP_DFLT)
+}
+
+func GetOptionExampleLhServicePort() string {
+	return fmt.Sprintf("--%s %d", SERVICE_NET_PORT, SERVICE_NET_PORT_DFLT)
+}
+
+func GetOptionExampleLhServiceInsecure() string {
+	return fmt.Sprintf("--%s", SERVICE_INSECURE)
+}
+
+func GetOptionExampleLhServiceProtocol() string {
+	return fmt.Sprintf("--%s %s", SERVICE_PROTOCOL, SERVICE_PROTOCOL_DFLT)
+}
+
+func GetOptionExampleLhApplianceId() string {
+	return fmt.Sprintf("--%s applianceId", APPLIANCE_ID)
+}
+
+func GetOptionExampleLhBladeId() string {
+	return fmt.Sprintf("--%s bladeId", BLADE_ID)
+}
+
+func GetOptionExampleLhHostId() string {
+	return fmt.Sprintf("--%s hostId", HOST_ID)
+}
+
+func GetOptionExampleLhNewId() string {
+	return fmt.Sprintf("--%s newId", NEW_ID)
+}
+
+func GetOptionExampleLhApplianceUsername() string {
+	return fmt.Sprintf("--%s %s", APPLIANCE_USERNAME, APPLIANCE_USERNAME_DFLT)
+}
+
+func GetOptionExampleLhAppliancePassword() string {
+	return fmt.Sprintf("--%s %s", APPLIANCE_PASSWORD, APPLIANCE_PASSWORD_DFLT)
+}
+
+func GetOptionExampleLhGroupApplianceTcp() string {
+	return fmt.Sprintf("%s %s %s %s",
+		GetOptionExampleLhApplianceIp(),
+		GetOptionExampleLhAppliancePort(),
+		GetOptionExampleLhApplianceInsecure(),
+		GetOptionExampleLhApplianceProtocol())
+}
+
+func GetOptionExampleLhApplianceIp() string {
+	return fmt.Sprintf("--%s %s", APPLIANCE_NET_IP, APPLIANCE_NET_IP_DFLT)
+}
+
+func GetOptionExampleLhAppliancePort() string {
+	return fmt.Sprintf("--%s %d", APPLIANCE_NET_PORT, APPLIANCE_NET_PORT_DFLT)
+}
+
+func GetOptionExampleLhApplianceInsecure() string {
+	return fmt.Sprintf("--%s", APPLIANCE_INSECURE)
+}
+
+func GetOptionExampleLhApplianceProtocol() string {
+	return fmt.Sprintf("--%s %s", APPLIANCE_PROTOCOL, APPLIANCE_PROTOCOL_DFLT)
+}
+
+func GetOptionExampleLhBladeUsername() string {
+	return fmt.Sprintf("--%s %s", BLADE_USERNAME, BLADE_USERNAME_DFLT)
+}
+
+func GetOptionExampleLhBladePassword() string {
+	return fmt.Sprintf("--%s %s", BLADE_PASSWORD, BLADE_PASSWORD_DFLT)
+}
+
+func GetOptionExampleLhGroupBladeTcp() string {
+	return fmt.Sprintf("%s %s %s %s",
+		GetOptionExampleLhBladeIp(),
+		GetOptionExampleLhBladePort(),
+		GetOptionExampleLhBladeInsecure(),
+		GetOptionExampleLhBladeProtocol())
+}
+
+func GetOptionExampleLhBladeIp() string {
+	return fmt.Sprintf("--%s %s", BLADE_NET_IP, BLADE_NET_IP_DFLT)
+}
+
+func GetOptionExampleLhBladePort() string {
+	return fmt.Sprintf("--%s %d", BLADE_NET_PORT, BLADE_NET_PORT_DFLT)
+}
+
+func GetOptionExampleLhBladeInsecure() string {
+	return fmt.Sprintf("--%s", BLADE_INSECURE)
+}
+
+func GetOptionExampleLhBladeProtocol() string {
+	return fmt.Sprintf("--%s %s", BLADE_PROTOCOL, BLADE_PROTOCOL_DFLT)
+}
+
+func GetOptionExampleLhHostUsername() string {
+	return fmt.Sprintf("--%s %s", HOST_USERNAME, HOST_USERNAME_DFLT)
+}
+
+func GetOptionExampleLhHostPassword() string {
+	return fmt.Sprintf("--%s %s", HOST_PASSWORD, HOST_PASSWORD_DFLT)
+}
+
+func GetOptionExampleLhGroupHostTcp() string {
+	return fmt.Sprintf("%s %s %s %s",
+		GetOptionExampleLhHostIp(),
+		GetOptionExampleLhHostPort(),
+		GetOptionExampleLhHostInsecure(),
+		GetOptionExampleLhHostProtocol())
+}
+
+func GetOptionExampleLhHostIp() string {
+	return fmt.Sprintf("--%s %s", HOST_NET_IP, HOST_NET_IP_DFLT)
+}
+
+func GetOptionExampleLhHostPort() string {
+	return fmt.Sprintf("--%s %d", HOST_NET_PORT, HOST_NET_PORT_DFLT)
+}
+
+func GetOptionExampleLhHostInsecure() string {
+	return fmt.Sprintf("--%s", HOST_INSECURE)
+}
+
+func GetOptionExampleLhHostProtocol() string {
+	return fmt.Sprintf("--%s %s", HOST_PROTOCOL, HOST_PROTOCOL_DFLT)
+}
+
+func GetOptionExampleLhMemoryId() string {
+	return fmt.Sprintf("--%s memoryId", MEMORY_ID)
+}
+
+func GetOptionExampleLhMemoryQos() string {
+	return fmt.Sprintf("--%s %d", MEMORY_QOS, MEMORY_QOS_DFLT)
+}
+
+func GetOptionExampleLhMemoryDeviceId() string {
+	return fmt.Sprintf("--%s memoryDeviceId", MEMORY_DEVICE_ID)
+}
+
+func GetOptionExampleLhPortId() string {
+	return fmt.Sprintf("--%s portId", PORT_ID)
+}
+
+func GetOptionExampleLhResourceId() string {
+	return fmt.Sprintf("--%s resourceId", RESOURCE_ID)
+}
+
+func GetOptionExampleLhResourceSize() string {
+	return fmt.Sprintf("--%s %s", RESOURCE_SIZE, SIZE_DFLT)
+}
+
+func GetOptionExampleShGroupServiceTcp() string {
+	return fmt.Sprintf("%s %s %s %s",
+		GetOptionExampleShServiceIp(),
+		GetOptionExampleShServicePort(),
+		GetOptionExampleShServiceInsecure(),
+		GetOptionExampleShServiceProtocol())
+}
+
+func GetOptionExampleShServiceIp() string {
+	return fmt.Sprintf("-%s %s", SERVICE_NET_IP_SH, SERVICE_NET_IP_DFLT)
+}
+
+func GetOptionExampleShServicePort() string {
+	return fmt.Sprintf("-%s %d", SERVICE_NET_PORT_SH, SERVICE_NET_PORT_DFLT)
+}
+
+func GetOptionExampleShServiceInsecure() string {
+	return fmt.Sprintf("-%s", SERVICE_INSECURE_SH)
+}
+
+func GetOptionExampleShServiceProtocol() string {
+	return fmt.Sprintf("-%s %s", SERVICE_PROTOCOL_SH, SERVICE_PROTOCOL_DFLT)
+}
+
+func GetOptionExampleShApplianceId() string {
+	return fmt.Sprintf("-%s applianceId", APPLIANCE_ID_SH)
+}
+
+func GetOptionExampleShBladeId() string {
+	return fmt.Sprintf("-%s bladeId", BLADE_ID_SH)
+}
+
+func GetOptionExampleShHostId() string {
+	return fmt.Sprintf("-%s hostId", HOST_ID_SH)
+}
+
+func GetOptionExampleShNewId() string {
+	return fmt.Sprintf("-%s newId", NEW_ID_SH)
+}
+
+func GetOptionExampleShApplianceUsername() string {
+	return fmt.Sprintf("-%s %s", APPLIANCE_USERNAME_SH, APPLIANCE_USERNAME_DFLT)
+}
+
+func GetOptionExampleShAppliancePassword() string {
+	return fmt.Sprintf("-%s %s", APPLIANCE_PASSWORD_SH, APPLIANCE_PASSWORD_DFLT)
+}
+
+func GetOptionExampleShGroupApplianceTcp() string {
+	return fmt.Sprintf("%s %s %s %s",
+		GetOptionExampleShApplianceIp(),
+		GetOptionExampleShAppliancePort(),
+		GetOptionExampleShApplianceInsecure(),
+		GetOptionExampleShApplianceProtocol())
+}
+
+func GetOptionExampleShApplianceIp() string {
+	return fmt.Sprintf("-%s %s", APPLIANCE_NET_IP_SH, APPLIANCE_NET_IP_DFLT)
+}
+
+func GetOptionExampleShAppliancePort() string {
+	return fmt.Sprintf("-%s %d", APPLIANCE_NET_PORT_SH, APPLIANCE_NET_PORT_DFLT)
+}
+
+func GetOptionExampleShApplianceInsecure() string {
+	return fmt.Sprintf("-%s", APPLIANCE_INSECURE_SH)
+}
+
+func GetOptionExampleShApplianceProtocol() string {
+	return fmt.Sprintf("-%s %s", APPLIANCE_PROTOCOL_SH, APPLIANCE_PROTOCOL_DFLT)
+}
+
+func GetOptionExampleShBladeUsername() string {
+	return fmt.Sprintf("-%s %s", BLADE_USERNAME_SH, BLADE_USERNAME_DFLT)
+}
+
+func GetOptionExampleShBladePassword() string {
+	return fmt.Sprintf("-%s %s", BLADE_PASSWORD_SH, BLADE_PASSWORD_DFLT)
+}
+
+func GetOptionExampleShGroupBladeTcp() string {
+	return fmt.Sprintf("%s %s %s %s",
+		GetOptionExampleShBladeIp(),
+		GetOptionExampleShBladePort(),
+		GetOptionExampleShBladeInsecure(),
+		GetOptionExampleShBladeProtocol())
+}
+
+func GetOptionExampleShBladeIp() string {
+	return fmt.Sprintf("-%s %s", BLADE_NET_IP_SH, BLADE_NET_IP_DFLT)
+}
+
+func GetOptionExampleShBladePort() string {
+	return fmt.Sprintf("-%s %d", BLADE_NET_PORT_SH, BLADE_NET_PORT_DFLT)
+}
+
+func GetOptionExampleShBladeInsecure() string {
+	return fmt.Sprintf("-%s", BLADE_INSECURE_SH)
+}
+
+func GetOptionExampleShBladeProtocol() string {
+	return fmt.Sprintf("-%s %s", BLADE_PROTOCOL_SH, BLADE_PROTOCOL_DFLT)
+}
+
+func GetOptionExampleShHostUsername() string {
+	return fmt.Sprintf("-%s %s", HOST_USERNAME_SH, HOST_USERNAME_DFLT)
+}
+
+func GetOptionExampleShHostPassword() string {
+	return fmt.Sprintf("-%s %s", HOST_PASSWORD_SH, HOST_PASSWORD_DFLT)
+}
+
+func GetOptionExampleShGroupHostTcp() string {
+	return fmt.Sprintf("%s %s %s %s",
+		GetOptionExampleShHostIp(),
+		GetOptionExampleShHostPort(),
+		GetOptionExampleShHostInsecure(),
+		GetOptionExampleShHostProtocol())
+}
+
+func GetOptionExampleShHostIp() string {
+	return fmt.Sprintf("-%s %s", HOST_NET_IP_SH, HOST_NET_IP_DFLT)
+}
+
+func GetOptionExampleShHostPort() string {
+	return fmt.Sprintf("-%s %d", HOST_NET_PORT_SH, HOST_NET_PORT_DFLT)
+}
+
+func GetOptionExampleShHostInsecure() string {
+	return fmt.Sprintf("-%s", HOST_INSECURE_SH)
+}
+
+func GetOptionExampleShHostProtocol() string {
+	return fmt.Sprintf("-%s %s", HOST_PROTOCOL_SH, HOST_PROTOCOL_DFLT)
+}
+
+func GetOptionExampleShMemoryId() string {
+	return fmt.Sprintf("-%s memoryId", MEMORY_ID_SH)
+}
+
+func GetOptionExampleShMemoryQos() string {
+	return fmt.Sprintf("-%s %d", MEMORY_QOS_SH, MEMORY_QOS_DFLT)
+}
+
+func GetOptionExampleShMemoryDeviceId() string {
+	return fmt.Sprintf("-%s memoryDeviceId", MEMORY_DEVICE_ID_SH)
+}
+
+func GetOptionExampleShPortId() string {
+	return fmt.Sprintf("-%s portId", PORT_ID_SH)
+}
+
+func GetOptionExampleShResourceId() string {
+	return fmt.Sprintf("-%s resourceId", RESOURCE_ID_SH)
+}
+
+func GetOptionExampleShResourceSize() string {
+	return fmt.Sprintf("-%s %s", RESOURCE_SIZE_SH, SIZE_DFLT)
+}

--- a/cli/pkg/serviceLib/flags/flags.go
+++ b/cli/pkg/serviceLib/flags/flags.go
@@ -4,8 +4,7 @@ package flags
 
 // CLI flag component descriptor
 const (
-	SERVICE       string = "serv"
-	DEVICE        string = "dev" //generic "device" for appliance OR host - future deprecation
+	SERVICE       string = "service"
 	APPLIANCE     string = "appliance"
 	BLADE         string = "blade"
 	HOST          string = "host"
@@ -13,6 +12,13 @@ const (
 	MEMORY_DEVICE string = "memory-device"
 	PORT          string = "port"
 	RESOURCE      string = "resource"
+
+	APPLIANCES     string = "appliances"
+	BLADES         string = "blades"
+	HOSTS          string = "hosts"
+	MEMORY_DEVICES string = "memory-devices"
+	PORTS          string = "ports"
+	RESOURCES      string = "resources"
 )
 
 // CLI flag detail descriptor
@@ -20,7 +26,7 @@ const (
 	ID       string = "id"
 	USERNAME string = "username"
 	PASSWORD string = "password"
-	NET_IP   string = "ip"
+	NET_IP   string = "net-ip"
 	NET_PORT string = "net-port"
 	INSECURE string = "insecure"
 	PROTOCOL string = "protocol"
@@ -40,9 +46,9 @@ const (
 	SERVICE_NET_PORT    string = SERVICE + "-" + NET_PORT
 	SERVICE_NET_PORT_SH string = "p"
 	SERVICE_INSECURE    string = SERVICE + "-" + INSECURE
-	SERVICE_INSECURE_SH string = "" //"s"
+	SERVICE_INSECURE_SH string = "s"
 	SERVICE_PROTOCOL    string = SERVICE + "-" + PROTOCOL
-	SERVICE_PROTOCOL_SH string = "" //"t"
+	SERVICE_PROTOCOL_SH string = "t"
 
 	APPLIANCE_ID    string = APPLIANCE + "-" + ID
 	APPLIANCE_ID_SH string = "L"
@@ -53,18 +59,51 @@ const (
 	NEW_ID          string = NEW + "-" + ID
 	NEW_ID_SH       string = "N"
 
-	DEVICE_USERNAME    string = DEVICE + "-" + USERNAME
-	DEVICE_USERNAME_SH string = "R"
-	DEVICE_PASSWORD    string = DEVICE + "-" + PASSWORD
-	DEVICE_PASSWORD_SH string = "W"
-	DEVICE_NET_IP      string = DEVICE + "-" + NET_IP
-	DEVICE_NET_IP_SH   string = "A"
-	DEVICE_NET_PORT    string = DEVICE + "-" + NET_PORT
-	DEVICE_NET_PORT_SH string = "P"
-	DEVICE_INSECURE    string = DEVICE + "-" + INSECURE
-	DEVICE_INSECURE_SH string = "S"
-	DEVICE_PROTOCOL    string = DEVICE + "-" + PROTOCOL
-	DEVICE_PROTOCOL_SH string = "T"
+	COMMON_USERNAME_SH string = "R"
+	COMMON_PASSWORD_SH string = "W"
+	COMMON_NET_IP_SH   string = "A"
+	COMMON_NET_PORT_SH string = "P"
+	COMMON_INSECURE_SH string = "S"
+	COMMON_PROTOCOL_SH string = "T"
+
+	APPLIANCE_USERNAME    string = APPLIANCE + "-" + USERNAME
+	APPLIANCE_USERNAME_SH string = COMMON_USERNAME_SH
+	APPLIANCE_PASSWORD    string = APPLIANCE + "-" + PASSWORD
+	APPLIANCE_PASSWORD_SH string = COMMON_PASSWORD_SH
+	APPLIANCE_NET_IP      string = APPLIANCE + "-" + NET_IP
+	APPLIANCE_NET_IP_SH   string = COMMON_NET_IP_SH
+	APPLIANCE_NET_PORT    string = APPLIANCE + "-" + NET_PORT
+	APPLIANCE_NET_PORT_SH string = COMMON_NET_PORT_SH
+	APPLIANCE_INSECURE    string = APPLIANCE + "-" + INSECURE
+	APPLIANCE_INSECURE_SH string = COMMON_INSECURE_SH
+	APPLIANCE_PROTOCOL    string = APPLIANCE + "-" + PROTOCOL
+	APPLIANCE_PROTOCOL_SH string = COMMON_PROTOCOL_SH
+
+	BLADE_USERNAME    string = BLADE + "-" + USERNAME
+	BLADE_USERNAME_SH string = COMMON_USERNAME_SH
+	BLADE_PASSWORD    string = BLADE + "-" + PASSWORD
+	BLADE_PASSWORD_SH string = COMMON_PASSWORD_SH
+	BLADE_NET_IP      string = BLADE + "-" + NET_IP
+	BLADE_NET_IP_SH   string = COMMON_NET_IP_SH
+	BLADE_NET_PORT    string = BLADE + "-" + NET_PORT
+	BLADE_NET_PORT_SH string = COMMON_NET_PORT_SH
+	BLADE_INSECURE    string = BLADE + "-" + INSECURE
+	BLADE_INSECURE_SH string = COMMON_INSECURE_SH
+	BLADE_PROTOCOL    string = BLADE + "-" + PROTOCOL
+	BLADE_PROTOCOL_SH string = COMMON_PROTOCOL_SH
+
+	HOST_USERNAME    string = HOST + "-" + USERNAME
+	HOST_USERNAME_SH string = COMMON_USERNAME_SH
+	HOST_PASSWORD    string = HOST + "-" + PASSWORD
+	HOST_PASSWORD_SH string = COMMON_PASSWORD_SH
+	HOST_NET_IP      string = HOST + "-" + NET_IP
+	HOST_NET_IP_SH   string = COMMON_NET_IP_SH
+	HOST_NET_PORT    string = HOST + "-" + NET_PORT
+	HOST_NET_PORT_SH string = COMMON_NET_PORT_SH
+	HOST_INSECURE    string = HOST + "-" + INSECURE
+	HOST_INSECURE_SH string = COMMON_INSECURE_SH
+	HOST_PROTOCOL    string = HOST + "-" + PROTOCOL
+	HOST_PROTOCOL_SH string = COMMON_PROTOCOL_SH
 
 	MEMORY_ID           string = MEMORY + "-" + ID
 	MEMORY_ID_SH        string = "m"
@@ -115,7 +154,7 @@ const (
 	HOST_USERNAME_DFLT string = "admin"
 	HOST_PASSWORD_DFLT string = "admin12345"
 
-	SIZE_DFLT string = "0"
+	SIZE_DFLT string = "8g"
 
 	MEMORY_QOS_DFLT = 4
 

--- a/cli/pkg/serviceLib/flags/usages.go
+++ b/cli/pkg/serviceLib/flags/usages.go
@@ -1,0 +1,196 @@
+// Copyright (c) 2024 Seagate Technology LLC and/or its Affiliates
+package flags
+
+import "fmt"
+
+// Family of getter functions to allow retrieval of consistent strings, for each option, when building the cobra.Command Usage field string across multiple commands.
+//
+// Usage syntax is defined as follows:
+// 1.) Square Brackets [ ]: Indicate optional elements. For example, in command [option], the option is not required for the command to run.
+// 2.) Angle Brackets < >: Often used to denote placeholders for user-supplied values, such as command <filename>.
+// 3.) Curly Braces { }: Indicate a set of choices, where you must choose one. For example, command {start|stop|restart} means you must choose one of start, stop, or restart.
+// 4.) Vertical Bar |: Used within curly braces to separate choices, as shown above.
+// 5.) Ellipsis ...: Indicates that the preceding element can be repeated multiple times. For example, command [option]... means you can use multiple options.
+// 6.) Parentheses ( ): Sometimes used to group elements together, though less common in man pages.
+// 7.) Bold Text: Typically used to show the command itself or mandatory elements.
+// 8.) Italic Text: Used for arguments or variables that the user must replace with actual values.
+
+// formatUsage - Generates a formatted usage string for a single command option.
+// Used for every option in the cobra.Command.Use field.
+// This function is meant to be called multiple times to consistently generate a complete string that represents the usage for a single cli command option.
+// String format(using all available features): [--option | -o <entry>]
+func formatUsage(option, shorthand, entry string, optional bool) string {
+	usage := fmt.Sprintf("{--%s | -%s}", option, shorthand)
+
+	if entry != "" {
+		usage = fmt.Sprintf("%s <%s>", usage, entry)
+	}
+
+	if optional {
+		usage = fmt.Sprintf("[%s]", usage)
+	} // else {
+	// 	usage = fmt.Sprintf("(%s)", usage)
+	// }
+
+	return usage
+}
+
+func GetOptionUsageGroupServiceTcp(optional bool) string {
+	return fmt.Sprintf("%s %s %s %s",
+		GetOptionUsageServiceIp(optional),
+		GetOptionUsageServicePort(optional),
+		GetOptionUsageServiceInsecure(optional),
+		GetOptionUsageServiceProtocol(optional))
+}
+
+func GetOptionUsageServiceIp(optional bool) string {
+	return formatUsage(SERVICE_NET_IP, SERVICE_NET_IP_SH, "ip_address", optional)
+}
+
+func GetOptionUsageServicePort(optional bool) string {
+	return formatUsage(SERVICE_NET_PORT, SERVICE_NET_PORT_SH, PORT, optional)
+}
+
+func GetOptionUsageServiceInsecure(optional bool) string {
+	return formatUsage(SERVICE_INSECURE, SERVICE_INSECURE_SH, "", optional)
+}
+
+func GetOptionUsageServiceProtocol(optional bool) string {
+	return formatUsage(SERVICE_PROTOCOL, SERVICE_PROTOCOL_SH, PROTOCOL, optional)
+}
+
+func GetOptionUsageApplianceId(optional bool) string {
+	return formatUsage(APPLIANCE_ID, APPLIANCE_ID_SH, "applianceId", optional)
+}
+
+func GetOptionUsageBladeId(optional bool) string {
+	return formatUsage(BLADE_ID, BLADE_ID_SH, "bladeId", optional)
+}
+
+func GetOptionUsageHostId(optional bool) string {
+	return formatUsage(HOST_ID, HOST_ID_SH, "hostId", optional)
+}
+
+func GetOptionUsageNewId(optional bool) string {
+	return formatUsage(NEW_ID, NEW_ID_SH, "newId", optional)
+}
+
+func GetOptionUsageApplianceUsername(optional bool) string {
+	return formatUsage(APPLIANCE_USERNAME, APPLIANCE_USERNAME_SH, USERNAME, optional)
+}
+
+func GetOptionUsageAppliancePassword(optional bool) string {
+	return formatUsage(APPLIANCE_PASSWORD, APPLIANCE_PASSWORD_SH, PASSWORD, optional)
+}
+
+func GetOptionUsageGroupApplianceTcp(optional bool) string {
+	return fmt.Sprintf("%s %s %s %s",
+		GetOptionUsageApplianceIp(optional),
+		GetOptionUsageAppliancePort(optional),
+		GetOptionUsageApplianceInsecure(optional),
+		GetOptionUsageApplianceProtocol(optional))
+}
+
+func GetOptionUsageApplianceIp(optional bool) string {
+	return formatUsage(APPLIANCE_NET_IP, APPLIANCE_NET_IP_SH, "ip_address", optional)
+}
+
+func GetOptionUsageAppliancePort(optional bool) string {
+	return formatUsage(APPLIANCE_NET_PORT, APPLIANCE_NET_PORT_SH, PORT, optional)
+}
+
+func GetOptionUsageApplianceInsecure(optional bool) string {
+	return formatUsage(APPLIANCE_INSECURE, APPLIANCE_INSECURE_SH, "", optional)
+}
+
+func GetOptionUsageApplianceProtocol(optional bool) string {
+	return formatUsage(APPLIANCE_PROTOCOL, APPLIANCE_PROTOCOL_SH, PROTOCOL, optional)
+}
+
+func GetOptionUsageBladeUsername(optional bool) string {
+	return formatUsage(BLADE_USERNAME, BLADE_USERNAME_SH, USERNAME, optional)
+}
+
+func GetOptionUsageBladePassword(optional bool) string {
+	return formatUsage(BLADE_PASSWORD, BLADE_PASSWORD_SH, PASSWORD, optional)
+}
+
+func GetOptionUsageGroupBladeTcp(optional bool) string {
+	return fmt.Sprintf("%s %s %s %s",
+		GetOptionUsageBladeIp(optional),
+		GetOptionUsageBladePort(optional),
+		GetOptionUsageBladeInsecure(optional),
+		GetOptionUsageBladeProtocol(optional))
+}
+
+func GetOptionUsageBladeIp(optional bool) string {
+	return formatUsage(BLADE_NET_IP, BLADE_NET_IP_SH, "ip_address", optional)
+}
+
+func GetOptionUsageBladePort(optional bool) string {
+	return formatUsage(BLADE_NET_PORT, BLADE_NET_PORT_SH, PORT, optional)
+}
+
+func GetOptionUsageBladeInsecure(optional bool) string {
+	return formatUsage(BLADE_INSECURE, BLADE_INSECURE_SH, "", optional)
+}
+
+func GetOptionUsageBladeProtocol(optional bool) string {
+	return formatUsage(BLADE_PROTOCOL, BLADE_PROTOCOL_SH, PROTOCOL, optional)
+}
+
+func GetOptionUsageHostUsername(optional bool) string {
+	return formatUsage(HOST_USERNAME, HOST_USERNAME_SH, USERNAME, optional)
+}
+
+func GetOptionUsageHostPassword(optional bool) string {
+	return formatUsage(HOST_PASSWORD, HOST_PASSWORD_SH, PASSWORD, optional)
+}
+
+func GetOptionUsageGroupHostTcp(optional bool) string {
+	return fmt.Sprintf("%s %s %s %s",
+		GetOptionUsageHostIp(optional),
+		GetOptionUsageHostPort(optional),
+		GetOptionUsageHostInsecure(optional),
+		GetOptionUsageHostProtocol(optional))
+}
+
+func GetOptionUsageHostIp(optional bool) string {
+	return formatUsage(HOST_NET_IP, HOST_NET_IP_SH, "ip_address", optional)
+}
+
+func GetOptionUsageHostPort(optional bool) string {
+	return formatUsage(HOST_NET_PORT, HOST_NET_PORT_SH, PORT, optional)
+}
+
+func GetOptionUsageHostInsecure(optional bool) string {
+	return formatUsage(HOST_INSECURE, HOST_INSECURE_SH, "", optional)
+}
+
+func GetOptionUsageHostProtocol(optional bool) string {
+	return formatUsage(HOST_PROTOCOL, HOST_PROTOCOL_SH, PROTOCOL, optional)
+}
+
+func GetOptionUsageMemoryId(optional bool) string {
+	return formatUsage(MEMORY_ID, MEMORY_ID_SH, "memoryId", optional)
+}
+
+func GetOptionUsageMemoryQos(optional bool) string {
+	return formatUsage(MEMORY_QOS, MEMORY_QOS_SH, QOS, optional)
+}
+
+func GetOptionUsageMemoryDeviceId(optional bool) string {
+	return formatUsage(MEMORY_DEVICE_ID, MEMORY_DEVICE_ID_SH, "memdevId", optional)
+}
+
+func GetOptionUsagePortId(optional bool) string {
+	return formatUsage(PORT_ID, PORT_ID_SH, "portId", optional)
+}
+
+func GetOptionUsageResourceId(optional bool) string {
+	return formatUsage(RESOURCE_ID, RESOURCE_ID_SH, "resourceId", optional)
+}
+
+func GetOptionUsageResourceSize(optional bool) string {
+	return formatUsage(RESOURCE_SIZE, RESOURCE_SIZE_SH, SIZE, optional)
+}

--- a/cli/pkg/serviceLib/serviceRequests/appliances.go
+++ b/cli/pkg/serviceLib/serviceRequests/appliances.go
@@ -28,8 +28,8 @@ func NewServiceRequestAddAppliance(cmd *cobra.Command) *ServiceRequestAddApplian
 	return &ServiceRequestAddAppliance{
 		ServiceTcp:    NewTcpInfo(cmd, flags.SERVICE),
 		ApplianceId:   NewId(cmd, flags.APPLIANCE),
-		ApplianceCred: NewDeviceCredentials(cmd, flags.DEVICE),
-		ApplianceTcp:  NewTcpInfo(cmd, flags.DEVICE),
+		ApplianceCred: NewDeviceCredentials(cmd, flags.APPLIANCE),
+		ApplianceTcp:  NewTcpInfo(cmd, flags.APPLIANCE),
 	}
 }
 

--- a/cli/pkg/serviceLib/serviceRequests/blades.go
+++ b/cli/pkg/serviceLib/serviceRequests/blades.go
@@ -27,8 +27,8 @@ func NewServiceRequestAddBlade(cmd *cobra.Command) *ServiceRequestAddBlade {
 		ServiceTcp:  NewTcpInfo(cmd, flags.SERVICE),
 		ApplianceId: NewId(cmd, flags.APPLIANCE),
 		BladeId:     NewId(cmd, flags.BLADE),
-		BladeCred:   NewDeviceCredentials(cmd, flags.DEVICE),
-		BladeTcp:    NewTcpInfo(cmd, flags.DEVICE),
+		BladeCred:   NewDeviceCredentials(cmd, flags.BLADE),
+		BladeTcp:    NewTcpInfo(cmd, flags.BLADE),
 	}
 }
 

--- a/cli/pkg/serviceLib/serviceRequests/hosts.go
+++ b/cli/pkg/serviceLib/serviceRequests/hosts.go
@@ -25,8 +25,8 @@ func NewServiceRequestAddHost(cmd *cobra.Command) *ServiceRequestAddHost {
 	return &ServiceRequestAddHost{
 		ServiceTcp: NewTcpInfo(cmd, flags.SERVICE),
 		HostId:     NewId(cmd, flags.HOST),
-		HostCred:   NewDeviceCredentials(cmd, flags.DEVICE),
-		HostTcp:    NewTcpInfo(cmd, flags.DEVICE),
+		HostCred:   NewDeviceCredentials(cmd, flags.HOST),
+		HostTcp:    NewTcpInfo(cmd, flags.HOST),
 	}
 }
 

--- a/cmd/cfm-cli/cmd/addAppliance.go
+++ b/cmd/cfm-cli/cmd/addAppliance.go
@@ -5,20 +5,18 @@ package cmd
 import (
 	"cfm/cli/pkg/serviceLib/flags"
 	"cfm/cli/pkg/serviceLib/serviceRequests"
+	"fmt"
 
 	"github.com/spf13/cobra"
 )
 
 var addApplianceCmd = &cobra.Command{
-	Use:   `appliance [--serv-ip | -a] [--serv-net-port | -p] [--appliance-id | -L]`,
+	Use:   GetCmdUsageAddAppliance(),
 	Short: "Add a memory appliance to cfm-service",
-	Long: `Create a virtual memeory appliance within the cfm-service.
+	Long: `Create a virtual memory appliance within the cfm-service.
            Use "cfm add blade" to add composable memory to the appliance.`,
-	Example: `
-	cfm add appliance --serv-ip 127.0.0.1 --serv-net-port 8080 --appliance-id userDefinedId
-
-	cfm add appliance -a 127.0.0.1 -p 8080 -L userDefinedId`,
-	Args: cobra.MatchAll(cobra.NoArgs),
+	Example: GetCmdExampleAddAppliance(),
+	Args:    cobra.MatchAll(cobra.NoArgs),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		initLogging(cmd)
 		return nil
@@ -40,17 +38,51 @@ func init() {
 
 	initCommonPersistentFlags(addApplianceCmd)
 
-	// Unused by user, but some values are required by cfm-service frontend.
-	addApplianceCmd.Flags().StringP(flags.DEVICE_USERNAME, flags.DEVICE_USERNAME_SH, flags.APPLIANCE_USERNAME_DFLT, "Appliance username for authentication")
-	addApplianceCmd.Flags().StringP(flags.DEVICE_PASSWORD, flags.DEVICE_PASSWORD_SH, flags.APPLIANCE_PASSWORD_DFLT, "Appliance password for authentication")
+	addApplianceCmd.Flags().StringP(flags.APPLIANCE_ID, flags.APPLIANCE_ID_SH, flags.ID_DFLT, "User-defined ID for target appliance (Optional)\n (default: random w\\ format: memory-appliance-XXXX)")
 
-	addApplianceCmd.Flags().StringP(flags.DEVICE_NET_IP, flags.DEVICE_NET_IP_SH, flags.APPLIANCE_NET_IP_DFLT, "Appliance network IP address")
-	addApplianceCmd.Flags().Uint16P(flags.DEVICE_NET_PORT, flags.DEVICE_NET_PORT_SH, flags.APPLIANCE_NET_PORT_DFLT, "Appliance network port ")
-	addApplianceCmd.Flags().BoolP(flags.DEVICE_INSECURE, flags.DEVICE_INSECURE_SH, flags.APPLIANCE_INSECURE_DFLT, "Appliance insecure connection flag")
-	addApplianceCmd.Flags().StringP(flags.DEVICE_PROTOCOL, flags.DEVICE_PROTOCOL_SH, flags.APPLIANCE_PROTOCOL_DFLT, "Appliance network connection protocol (http/https)")
+	// Unused by user, but values are required by cfm-service client frontend.
+	addApplianceCmd.Flags().StringP(flags.APPLIANCE_USERNAME, flags.APPLIANCE_USERNAME_SH, flags.APPLIANCE_USERNAME_DFLT, "Appliance username for authentication\n")
+	addApplianceCmd.Flags().StringP(flags.APPLIANCE_PASSWORD, flags.APPLIANCE_PASSWORD_SH, flags.APPLIANCE_PASSWORD_DFLT, "Appliance password for authentication\n")
+	addApplianceCmd.Flags().MarkHidden(flags.APPLIANCE_USERNAME)
+	addApplianceCmd.Flags().MarkHidden(flags.APPLIANCE_PASSWORD)
 
-	addApplianceCmd.Flags().StringP(flags.APPLIANCE_ID, flags.APPLIANCE_ID_SH, flags.ID_DFLT, "User-defined ID for target appliance")
+	addApplianceCmd.Flags().StringP(flags.APPLIANCE_NET_IP, flags.APPLIANCE_NET_IP_SH, flags.APPLIANCE_NET_IP_DFLT, "Appliance network IP address\n")
+	addApplianceCmd.Flags().Uint16P(flags.APPLIANCE_NET_PORT, flags.APPLIANCE_NET_PORT_SH, flags.APPLIANCE_NET_PORT_DFLT, "Appliance network port\n")
+	addApplianceCmd.Flags().BoolP(flags.APPLIANCE_INSECURE, flags.APPLIANCE_INSECURE_SH, flags.APPLIANCE_INSECURE_DFLT, "Appliance insecure connection flag\n (default false)")
+	addApplianceCmd.Flags().StringP(flags.APPLIANCE_PROTOCOL, flags.APPLIANCE_PROTOCOL_SH, flags.APPLIANCE_PROTOCOL_DFLT, "Appliance network connection protocol (http/https)\n")
+	addApplianceCmd.Flags().MarkHidden(flags.APPLIANCE_NET_IP)
+	addApplianceCmd.Flags().MarkHidden(flags.APPLIANCE_NET_PORT)
+	addApplianceCmd.Flags().MarkHidden(flags.APPLIANCE_INSECURE)
+	addApplianceCmd.Flags().MarkHidden(flags.APPLIANCE_PROTOCOL)
 
 	//Add command to parent
 	addCmd.AddCommand(addApplianceCmd)
+}
+
+// GetCmdUsageAddAppliance - Generates the command usage string for the cobra.Command.Use field.
+func GetCmdUsageAddAppliance() string {
+	return fmt.Sprintf("%s %s %s",
+		flags.APPLIANCE, // Note: The first word in the Command.Use string is how Cobra defines the "name" of this "command".
+		flags.GetOptionUsageGroupServiceTcp(false),
+		flags.GetOptionUsageApplianceId(true))
+}
+
+// GetCmdExampleAddAppliance - Generates the command example string for the cobra.Command.Example field.
+func GetCmdExampleAddAppliance() string {
+	baseCmd := fmt.Sprintf("cfm add %s", flags.APPLIANCE)
+
+	shorthandFormat := fmt.Sprintf("%s %s %s",
+		baseCmd,
+		flags.GetOptionExampleShGroupServiceTcp(),
+		flags.GetOptionExampleShApplianceId())
+
+	longhandFormat := fmt.Sprintf("%s %s %s",
+		baseCmd,
+		flags.GetOptionExampleLhGroupServiceTcp(),
+		flags.GetOptionExampleLhApplianceId())
+
+	return fmt.Sprintf(`
+	%s
+
+	%s`, shorthandFormat, longhandFormat)
 }

--- a/cmd/cfm-cli/cmd/addBlade.go
+++ b/cmd/cfm-cli/cmd/addBlade.go
@@ -5,20 +5,17 @@ package cmd
 import (
 	"cfm/cli/pkg/serviceLib/flags"
 	"cfm/cli/pkg/serviceLib/serviceRequests"
+	"fmt"
 
 	"github.com/spf13/cobra"
 )
 
 var addBladeCmd = &cobra.Command{
-	Use: `blade <--appliance-id | -L> [--dev-username | -R] [--dev-password | -W] [--serv-ip | -a] [--serv-net-port | -p]
-		[--blade-id | -B] [--dev-ip | -A] [--dev-net-port | -P] [--dev-insecure | -S] [--dev-protocol | -T]`,
-	Short: "Add a memory appliance blade connection to cfm-service",
-	Long:  `Adds a netowrk connection from the cfm-service to an external memory appliance blade.`,
-	Example: `
-	cfm add blade --serv-ip 127.0.0.1 --serv-net-port 8080 --appliance-id applId --blade-id userDefinedId --dev-username user --dev-password pswd --dev-ip 127.0.0.1 --dev-net-port 7443 --dev-insecure --dev-protocol https
-
-	cfm add blade -a 127.0.0.1 -p 8080 -L applId -B userDefinedId -R user -W pswd -A 127.0.0.1 -P 7443 -S -T https`,
-	Args: cobra.MatchAll(cobra.NoArgs),
+	Use:     GetCmdUsageAddBlade(),
+	Short:   "Add a memory appliance blade connection to cfm-service",
+	Long:    `Adds a netowrk connection from the cfm-service to an external memory appliance blade.`,
+	Example: GetCmdExampleAddBlade(),
+	Args:    cobra.MatchAll(cobra.NoArgs),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		initLogging(cmd)
 		return nil
@@ -40,20 +37,60 @@ func init() {
 
 	initCommonPersistentFlags(addBladeCmd)
 
-	addBladeCmd.Flags().StringP(flags.DEVICE_USERNAME, flags.DEVICE_USERNAME_SH, flags.BLADE_USERNAME_DFLT, "Blade username for authentication")
-	// addBladeCmd.MarkFlagRequired(flags.DEVICE_USERNAME)
-	addBladeCmd.Flags().StringP(flags.DEVICE_PASSWORD, flags.DEVICE_PASSWORD_SH, flags.BLADE_PASSWORD_DFLT, "Blade password for authentication")
-	// addBladeCmd.MarkFlagRequired(flags.DEVICE_PASSWORD)
+	addBladeCmd.Flags().StringP(flags.BLADE_USERNAME, flags.BLADE_USERNAME_SH, flags.BLADE_USERNAME_DFLT, "Blade username for authentication\n")
+	// addBladeCmd.MarkFlagRequired(flags.BLADE_USERNAME)
+	addBladeCmd.Flags().StringP(flags.BLADE_PASSWORD, flags.BLADE_PASSWORD_SH, flags.BLADE_PASSWORD_DFLT, "Blade password for authentication\n")
+	// addBladeCmd.MarkFlagRequired(flags.BLADE_PASSWORD)
 
-	addBladeCmd.Flags().StringP(flags.DEVICE_NET_IP, flags.DEVICE_NET_IP_SH, flags.BLADE_NET_IP_DFLT, "Blade network IP address")
-	addBladeCmd.Flags().Uint16P(flags.DEVICE_NET_PORT, flags.DEVICE_NET_PORT_SH, flags.BLADE_NET_PORT_DFLT, "Blade network port ")
-	addBladeCmd.Flags().BoolP(flags.DEVICE_INSECURE, flags.DEVICE_INSECURE_SH, flags.BLADE_INSECURE_DFLT, "Blade insecure connection flag")
-	addBladeCmd.Flags().StringP(flags.DEVICE_PROTOCOL, flags.DEVICE_PROTOCOL_SH, flags.BLADE_PROTOCOL_DFLT, "Blade network connection protocol (http/https)")
+	addBladeCmd.Flags().StringP(flags.BLADE_NET_IP, flags.BLADE_NET_IP_SH, flags.BLADE_NET_IP_DFLT, "Blade network IP address\n")
+	addBladeCmd.Flags().Uint16P(flags.BLADE_NET_PORT, flags.BLADE_NET_PORT_SH, flags.BLADE_NET_PORT_DFLT, "Blade network port\n")
+	addBladeCmd.Flags().BoolP(flags.BLADE_INSECURE, flags.BLADE_INSECURE_SH, flags.BLADE_INSECURE_DFLT, "Blade insecure connection flag\n (default false)")
+	addBladeCmd.Flags().StringP(flags.BLADE_PROTOCOL, flags.BLADE_PROTOCOL_SH, flags.BLADE_PROTOCOL_DFLT, "Blade network connection protocol (http/https)\n")
 
-	addBladeCmd.Flags().StringP(flags.APPLIANCE_ID, flags.APPLIANCE_ID_SH, flags.ID_DFLT, "Appliance ID of target blade")
+	addBladeCmd.Flags().StringP(flags.APPLIANCE_ID, flags.APPLIANCE_ID_SH, flags.ID_DFLT, "Appliance ID of target blade\n")
 	addBladeCmd.MarkFlagRequired(flags.APPLIANCE_ID)
-	addBladeCmd.Flags().StringP(flags.BLADE_ID, flags.BLADE_ID_SH, flags.ID_DFLT, "User-defined ID for target blade")
+	addBladeCmd.Flags().StringP(flags.BLADE_ID, flags.BLADE_ID_SH, flags.ID_DFLT, "User-defined ID for target blade (Optional)\n (default: random w\\ format: blade-XXXX)")
 
 	//Add command to parent
 	addCmd.AddCommand(addBladeCmd)
+}
+
+// GetCmdUsageAddBlade - Generates the command usage string for the cobra.Command.Use field.
+func GetCmdUsageAddBlade() string {
+	return fmt.Sprintf("%s %s %s %s %s %s %s",
+		flags.BLADE, // Note: The first word in the Command.Use string is how Cobra defines the "name" of this "command".
+		flags.GetOptionUsageGroupServiceTcp(false),
+		flags.GetOptionUsageApplianceId(false),
+		flags.GetOptionUsageBladeId(true),
+		flags.GetOptionUsageGroupBladeTcp(false),
+		flags.GetOptionUsageBladeUsername(false),
+		flags.GetOptionUsageBladePassword(false))
+}
+
+// GetCmdExampleAddBlade - Generates the command example string for the cobra.Command.Example field.
+func GetCmdExampleAddBlade() string {
+	baseCmd := fmt.Sprintf("cfm add %s", flags.BLADE)
+
+	shorthandFormat := fmt.Sprintf("%s %s %s %s %s %s %s",
+		baseCmd,
+		flags.GetOptionExampleShGroupServiceTcp(),
+		flags.GetOptionExampleShApplianceId(),
+		flags.GetOptionExampleShBladeId(),
+		flags.GetOptionExampleShGroupBladeTcp(),
+		flags.GetOptionExampleShBladeUsername(),
+		flags.GetOptionExampleShBladePassword())
+
+	longhandFormat := fmt.Sprintf("%s %s %s %s %s %s %s",
+		baseCmd,
+		flags.GetOptionExampleLhGroupServiceTcp(),
+		flags.GetOptionExampleLhApplianceId(),
+		flags.GetOptionExampleLhBladeId(),
+		flags.GetOptionExampleLhGroupBladeTcp(),
+		flags.GetOptionExampleLhBladeUsername(),
+		flags.GetOptionExampleLhBladePassword())
+
+	return fmt.Sprintf(`
+	%s
+
+	%s`, shorthandFormat, longhandFormat)
 }

--- a/cmd/cfm-cli/cmd/addHost.go
+++ b/cmd/cfm-cli/cmd/addHost.go
@@ -5,21 +5,18 @@ package cmd
 import (
 	"cfm/cli/pkg/serviceLib/flags"
 	"cfm/cli/pkg/serviceLib/serviceRequests"
+	"fmt"
 
 	"github.com/spf13/cobra"
 )
 
 // addHostCmd represents the addHost command
 var addHostCmd = &cobra.Command{
-	Use: `host [--dev-username | -R] [--dev-password | -W] [--serv-ip | -a] [--serv-net-port | -p]
-			[--host-id | -H] [--dev-ip | -A] [--dev-net-port | -P] [--dev-insecure | -S] [--dev-protocol | -T]`,
-	Short: "Add a cxl host connection to cfm-service",
-	Long:  `Adds a netowrk connection from the cfm-service to an external cxl host.`,
-	Example: `
-	cfm add host --serv-ip 127.0.0.1 --serv-net-port 8080 --host-id userDefinedId --dev-username user --dev-password pswd --dev-ip 127.0.0.1 --dev-net-port 7443 --dev-insecure --dev-protocol https
-
-	cfm add host -a 127.0.0.1 -p 8080 -H userDefinedId -R user -W pswd -A 127.0.0.1 -P 7443 -S -T https`,
-	Args: cobra.MatchAll(cobra.NoArgs),
+	Use:     GetCmdUsageAddHost(),
+	Short:   "Add a cxl host connection to cfm-service",
+	Long:    `Adds a netowrk connection from the cfm-service to an external cxl host.`,
+	Example: GetCmdExampleAddHost(),
+	Args:    cobra.MatchAll(cobra.NoArgs),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		initLogging(cmd)
 		return nil
@@ -41,18 +38,55 @@ func init() {
 
 	initCommonPersistentFlags(addHostCmd)
 
-	addHostCmd.Flags().StringP(flags.DEVICE_USERNAME, flags.DEVICE_USERNAME_SH, flags.HOST_USERNAME_DFLT, "Host username for authentication")
-	// addHostCmd.MarkFlagRequired(flags.DEVICE_USERNAME)
-	addHostCmd.Flags().StringP(flags.DEVICE_PASSWORD, flags.DEVICE_PASSWORD_SH, flags.HOST_PASSWORD_DFLT, "Host password for authentication")
-	// addHostCmd.MarkFlagRequired(flags.DEVICE_PASSWORD)
+	addHostCmd.Flags().StringP(flags.HOST_USERNAME, flags.HOST_USERNAME_SH, flags.HOST_USERNAME_DFLT, "Host(CXL) username for authentication\n")
+	// addHostCmd.MarkFlagRequired(flags.HOST_USERNAME)
+	addHostCmd.Flags().StringP(flags.HOST_PASSWORD, flags.HOST_PASSWORD_SH, flags.HOST_PASSWORD_DFLT, "Host(CXL) password for authentication\n")
+	// addHostCmd.MarkFlagRequired(flags.HOST_PASSWORD)
 
-	addHostCmd.Flags().StringP(flags.DEVICE_NET_IP, flags.DEVICE_NET_IP_SH, flags.HOST_NET_IP_DFLT, "Host network IP address")
-	addHostCmd.Flags().Uint16P(flags.DEVICE_NET_PORT, flags.DEVICE_NET_PORT_SH, flags.HOST_NET_PORT_DFLT, "Host network port ")
-	addHostCmd.Flags().BoolP(flags.DEVICE_INSECURE, flags.DEVICE_INSECURE_SH, flags.HOST_INSECURE_DFLT, "Host insecure connection flag")
-	addHostCmd.Flags().StringP(flags.DEVICE_PROTOCOL, flags.DEVICE_PROTOCOL_SH, flags.HOST_PROTOCOL_DFLT, "Host network connection protocol (http/https)")
+	addHostCmd.Flags().StringP(flags.HOST_NET_IP, flags.HOST_NET_IP_SH, flags.HOST_NET_IP_DFLT, "Host(CXL) network IP address\n")
+	addHostCmd.Flags().Uint16P(flags.HOST_NET_PORT, flags.HOST_NET_PORT_SH, flags.HOST_NET_PORT_DFLT, "Host(CXL) network port\n")
+	addHostCmd.Flags().BoolP(flags.HOST_INSECURE, flags.HOST_INSECURE_SH, flags.HOST_INSECURE_DFLT, "Host(CXL) insecure connection flag\n (default false)")
+	addHostCmd.Flags().StringP(flags.HOST_PROTOCOL, flags.HOST_PROTOCOL_SH, flags.HOST_PROTOCOL_DFLT, "Host(CXL) network connection protocol (http/https)\n")
 
-	addHostCmd.Flags().StringP(flags.HOST_ID, flags.HOST_ID_SH, flags.ID_DFLT, "User-defined ID for target host")
+	addHostCmd.Flags().StringP(flags.HOST_ID, flags.HOST_ID_SH, flags.ID_DFLT, "User-defined ID for target host(CXL) (Optional)\n (default: random w\\ format: host-XXXX)")
 
 	//Add command to parent
 	addCmd.AddCommand(addHostCmd)
+}
+
+// GetCmdUsageAddHost - Generates the command usage string for the cobra.Command.Use field.
+func GetCmdUsageAddHost() string {
+	return fmt.Sprintf("%s %s %s %s %s %s",
+		flags.HOST, // Note: The first word in the Command.Use string is how Cobra defines the "name" of this "command".
+		flags.GetOptionUsageGroupServiceTcp(false),
+		flags.GetOptionUsageHostId(true),
+		flags.GetOptionUsageGroupHostTcp(false),
+		flags.GetOptionUsageHostUsername(false),
+		flags.GetOptionUsageHostPassword(false))
+}
+
+// GetCmdExampleAddHost - Generates the command example string for the cobra.Command.Example field.
+func GetCmdExampleAddHost() string {
+	baseCmd := fmt.Sprintf("cfm add %s", flags.HOST)
+
+	shorthandFormat := fmt.Sprintf("%s %s %s %s %s %s",
+		baseCmd,
+		flags.GetOptionExampleShGroupServiceTcp(),
+		flags.GetOptionExampleShHostId(),
+		flags.GetOptionExampleShGroupHostTcp(),
+		flags.GetOptionExampleShHostUsername(),
+		flags.GetOptionExampleShHostPassword())
+
+	longhandFormat := fmt.Sprintf("%s %s %s %s %s %s",
+		baseCmd,
+		flags.GetOptionExampleLhGroupServiceTcp(),
+		flags.GetOptionExampleLhHostId(),
+		flags.GetOptionExampleLhGroupHostTcp(),
+		flags.GetOptionExampleLhHostUsername(),
+		flags.GetOptionExampleLhHostPassword())
+
+	return fmt.Sprintf(`
+	%s
+
+	%s`, shorthandFormat, longhandFormat)
 }

--- a/cmd/cfm-cli/cmd/assignBlade.go
+++ b/cmd/cfm-cli/cmd/assignBlade.go
@@ -11,14 +11,11 @@ import (
 )
 
 var assignBladeCmd = &cobra.Command{
-	Use:   "blade  [--serv-ip | -a] [--serv-net-port | -p] <--appliance-id | -L>  <--blade-id | -B> <--memory-id | -m> <--port-id | -o>",
-	Short: "Assign an existing blade memory region to a blade port.",
-	Long:  `Assign an existing blade memory region to a blade port.  A physical connection must already exist between the appliance blade and the target cxl-host.`,
-	Example: `
-	cfm assign blade --serv-ip 127.0.0.1 --serv-net-port 8080 --appliance-id applId --blade-id bladeId --memory-id memoryId --port-id portId
-
-	cfm assign blade -a 127.0.0.1 -p 8080 -L applId  -B bladeId -m memoryId -o portId`,
-	Args: cobra.MatchAll(cobra.NoArgs),
+	Use:     GetCmdUsageAssignBlade(),
+	Short:   "Assign an existing blade memory region to a blade port.",
+	Long:    `Assign an existing blade memory region to a blade port.  A physical connection must already exist between the appliance blade and the target cxl-host.`,
+	Example: GetCmdExampleAssignBlade(),
+	Args:    cobra.MatchAll(cobra.NoArgs),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		initLogging(cmd)
 		return nil
@@ -44,17 +41,54 @@ var assignBladeCmd = &cobra.Command{
 func init() {
 	assignBladeCmd.DisableFlagsInUseLine = true
 
-	assignBladeCmd.Flags().StringP(flags.APPLIANCE_ID, flags.APPLIANCE_ID_SH, flags.ID_DFLT, "ID of appliance to interrogate")
+	assignBladeCmd.Flags().StringP(flags.APPLIANCE_ID, flags.APPLIANCE_ID_SH, flags.ID_DFLT, "ID of appliance to interrogate\n")
 	assignBladeCmd.MarkFlagRequired(flags.APPLIANCE_ID)
-	assignBladeCmd.Flags().StringP(flags.BLADE_ID, flags.BLADE_ID_SH, flags.ID_DFLT, "ID of appliance blade to interrogate")
+	assignBladeCmd.Flags().StringP(flags.BLADE_ID, flags.BLADE_ID_SH, flags.ID_DFLT, "ID of appliance blade to interrogate\n")
 	assignBladeCmd.MarkFlagRequired(flags.BLADE_ID)
-	assignBladeCmd.Flags().StringP(flags.MEMORY_ID, flags.MEMORY_ID_SH, flags.ID_DFLT, "ID of the appliance blade memory region to assign to the specified port.")
+	assignBladeCmd.Flags().StringP(flags.MEMORY_ID, flags.MEMORY_ID_SH, flags.ID_DFLT, "ID of the appliance blade memory region to assign to the specified port\n")
 	assignBladeCmd.MarkFlagRequired(flags.MEMORY_ID)
-	assignBladeCmd.Flags().StringP(flags.PORT_ID, flags.PORT_ID_SH, flags.ID_DFLT, "ID of the appliance blade port to assign to the specified memory region.")
+	assignBladeCmd.Flags().StringP(flags.PORT_ID, flags.PORT_ID_SH, flags.ID_DFLT, "ID of the appliance blade port to assign to the specified memory region\n")
 	assignBladeCmd.MarkFlagRequired(flags.PORT_ID)
 
 	initCommonPersistentFlags(assignBladeCmd)
 
 	//Add command to parent
 	assignCmd.AddCommand(assignBladeCmd)
+}
+
+// GetCmdUsageAssignBlade - Generates the command usage string for the cobra.Command.Use field.
+func GetCmdUsageAssignBlade() string {
+	return fmt.Sprintf("%s %s %s %s %s %s",
+		flags.BLADE, // Note: The first word in the Command.Use string is how Cobra defines the "name" of this "command".
+		flags.GetOptionUsageGroupServiceTcp(false),
+		flags.GetOptionUsageApplianceId(false),
+		flags.GetOptionUsageBladeId(false),
+		flags.GetOptionUsageMemoryId(false),
+		flags.GetOptionUsagePortId(false))
+}
+
+// GetCmdExampleAssignBlade - Generates the command example string for the cobra.Command.Example field.
+func GetCmdExampleAssignBlade() string {
+	baseCmd := fmt.Sprintf("cfm assign %s", flags.BLADE)
+
+	shorthandFormat := fmt.Sprintf("%s %s %s %s %s %s",
+		baseCmd,
+		flags.GetOptionExampleShGroupServiceTcp(),
+		flags.GetOptionExampleShApplianceId(),
+		flags.GetOptionExampleShBladeId(),
+		flags.GetOptionExampleShMemoryId(),
+		flags.GetOptionExampleShPortId())
+
+	longhandFormat := fmt.Sprintf("%s %s %s %s %s %s",
+		baseCmd,
+		flags.GetOptionExampleLhGroupServiceTcp(),
+		flags.GetOptionExampleLhApplianceId(),
+		flags.GetOptionExampleLhBladeId(),
+		flags.GetOptionExampleLhMemoryId(),
+		flags.GetOptionExampleLhPortId())
+
+	return fmt.Sprintf(`
+	%s
+
+	%s`, shorthandFormat, longhandFormat)
 }

--- a/cmd/cfm-cli/cmd/composeBlade.go
+++ b/cmd/cfm-cli/cmd/composeBlade.go
@@ -11,14 +11,11 @@ import (
 )
 
 var composeBladeCmd = &cobra.Command{
-	Use:   "blade  [--serv-ip | -a] [--serv-net-port | -p] <--appliance-id | -L>  <--blade-id | -B> [--port-id | -i] <--resource-size | -z> [--memory-qos | -q]",
-	Short: "Compose a new memory region on the specified memory appliance blade.",
-	Long:  `Compose a new memory region on the specified memory appliance blade.  The composed memory region can be optionally assigned to a specified memory appliance blade port for use by an external device (such as a cxl host).`,
-	Example: `
-	cfm compose blade --serv-ip 127.0.0.1 --serv-net-port 8080 --appliance-id applId --blade-id bladeId --port-id portId --resource-size 32g --memory-qos 4
-
-	cfm compose blade -a 127.0.0.1 -p 8080 -L applId  -B bladeId -o portId -z 32g -q 4`,
-	Args: cobra.MatchAll(cobra.NoArgs),
+	Use:     GetCmdUsageComposeBlade(),
+	Short:   "Compose a new memory region on the specified memory appliance blade.",
+	Long:    `Compose a new memory region on the specified memory appliance blade.  The composed memory region can be optionally assigned to a specified memory appliance blade port for use by an external device (such as a cxl host).`,
+	Example: GetCmdExampleComposeBlade(),
+	Args:    cobra.MatchAll(cobra.NoArgs),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		initLogging(cmd)
 		return nil
@@ -47,17 +44,68 @@ var composeBladeCmd = &cobra.Command{
 func init() {
 	composeBladeCmd.DisableFlagsInUseLine = true
 
-	composeBladeCmd.Flags().StringP(flags.APPLIANCE_ID, flags.APPLIANCE_ID_SH, flags.ID_DFLT, "ID of appliance to interrogate")
+	composeBladeCmd.Flags().StringP(flags.APPLIANCE_ID, flags.APPLIANCE_ID_SH, flags.ID_DFLT, "ID of appliance to interrogate\n")
 	composeBladeCmd.MarkFlagRequired(flags.APPLIANCE_ID)
-	composeBladeCmd.Flags().StringP(flags.BLADE_ID, flags.BLADE_ID_SH, flags.ID_DFLT, "ID of appliance blade to interrogate")
+	composeBladeCmd.Flags().StringP(flags.BLADE_ID, flags.BLADE_ID_SH, flags.ID_DFLT, "ID of appliance blade to interrogate\n")
 	composeBladeCmd.MarkFlagRequired(flags.BLADE_ID)
-	composeBladeCmd.Flags().StringP(flags.PORT_ID, flags.PORT_ID_SH, flags.ID_DFLT, "ID of a specific appliance port.")
-	composeBladeCmd.Flags().StringP(flags.RESOURCE_SIZE, flags.RESOURCE_SIZE_SH, flags.SIZE_DFLT, "Total size of new, composed memory region(minimum of 1 GiB). Use 'G' or 'g' to specific GiB.")
+	composeBladeCmd.Flags().StringP(flags.PORT_ID, flags.PORT_ID_SH, flags.ID_DFLT, "ID of a specific appliance port\n")
+	composeBladeCmd.Flags().StringP(flags.RESOURCE_SIZE, flags.RESOURCE_SIZE_SH, flags.SIZE_DFLT, "Total size of new, composed memory region(minimum of 1 GiB). Use 'G' or 'g' to specify GiB\n")
 	composeBladeCmd.MarkFlagRequired(flags.RESOURCE_SIZE)
-	composeBladeCmd.Flags().Int32P(flags.MEMORY_QOS, flags.MEMORY_QOS_SH, flags.MEMORY_QOS_DFLT, "NOT YET SUPPORTED, BUT, for now, cfm-service ***REQUIRES*** this to be 4: Quality of Service level.")
+	composeBladeCmd.Flags().Int32P(flags.MEMORY_QOS, flags.MEMORY_QOS_SH, flags.MEMORY_QOS_DFLT, "Quality of Service level (ie: channel bandwidth)\n")
+	composeBladeCmd.MarkFlagRequired(flags.MEMORY_QOS)
 
 	initCommonPersistentFlags(composeBladeCmd)
 
 	//Add command to parent
 	composeCmd.AddCommand(composeBladeCmd)
+}
+
+// GetCmdUsageComposeBlade - Generates the command usage string for the cobra.Command.Use field.
+func GetCmdUsageComposeBlade() string {
+	return fmt.Sprintf("%s %s %s %s %s %s %s",
+		flags.BLADE, // Note: The first word in the Command.Use string is how Cobra defines the "name" of this "command".
+		flags.GetOptionUsageGroupServiceTcp(false),
+		flags.GetOptionUsageApplianceId(false),
+		flags.GetOptionUsageBladeId(false),
+		flags.GetOptionUsagePortId(true),
+		flags.GetOptionUsageResourceSize(false),
+		flags.GetOptionUsageMemoryQos(false))
+}
+
+// GetCmdExampleComposeBlade - Generates the command example string for the cobra.Command.Example field.
+func GetCmdExampleComposeBlade() string {
+	baseCmd := fmt.Sprintf("cfm compose %s", flags.BLADE)
+
+	shorthandFormat := fmt.Sprintf("%s %s %s %s %s %s %s",
+		baseCmd,
+		flags.GetOptionExampleShGroupServiceTcp(),
+		flags.GetOptionExampleShApplianceId(),
+		flags.GetOptionExampleShBladeId(),
+		flags.GetOptionExampleShPortId(),
+		flags.GetOptionExampleShResourceSize(),
+		flags.GetOptionExampleShMemoryQos())
+
+	shorthandFormat2 := fmt.Sprintf("%s %s %s %s %s %s",
+		baseCmd,
+		flags.GetOptionExampleShGroupServiceTcp(),
+		flags.GetOptionExampleShApplianceId(),
+		flags.GetOptionExampleShBladeId(),
+		flags.GetOptionExampleShResourceSize(),
+		flags.GetOptionExampleShMemoryQos())
+
+	longhandFormat := fmt.Sprintf("%s %s %s %s %s %s %s",
+		baseCmd,
+		flags.GetOptionExampleLhGroupServiceTcp(),
+		flags.GetOptionExampleLhApplianceId(),
+		flags.GetOptionExampleLhBladeId(),
+		flags.GetOptionExampleLhPortId(),
+		flags.GetOptionExampleLhResourceSize(),
+		flags.GetOptionExampleLhMemoryQos())
+
+	return fmt.Sprintf(`
+	%s
+
+	%s
+
+	%s`, shorthandFormat, shorthandFormat2, longhandFormat)
 }

--- a/cmd/cfm-cli/cmd/deleteAppliance.go
+++ b/cmd/cfm-cli/cmd/deleteAppliance.go
@@ -5,19 +5,17 @@ package cmd
 import (
 	"cfm/cli/pkg/serviceLib/flags"
 	"cfm/cli/pkg/serviceLib/serviceRequests"
+	"fmt"
 
 	"github.com/spf13/cobra"
 )
 
 var deleteApplianceCmd = &cobra.Command{
-	Use:   `appliance [--serv-ip | -a] [--serv-net-port | -p] <--appliance-id | -L>`,
-	Short: "Delete a memory appliance connection from cfm-service",
-	Long:  `Deletes a netowrk connection from the cfm-service to an external memory appliance.`,
-	Example: `
-	cfm delete appliance --appliance-id applId --serv-ip 127.0.0.1 --serv-net-port 8080
-
-	cfm delete appliance -L applId -a 127.0.0.1 -p 8080`,
-	Args: cobra.MatchAll(cobra.NoArgs),
+	Use:     GetCmdUsageDeleteAppliance(),
+	Short:   "Delete a memory appliance connection from cfm-service",
+	Long:    `Deletes a netowrk connection from the cfm-service to an external memory appliance.`,
+	Example: GetCmdExampleDeleteAppliance(),
+	Args:    cobra.MatchAll(cobra.NoArgs),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		initLogging(cmd)
 		return nil
@@ -39,8 +37,37 @@ func init() {
 
 	initCommonPersistentFlags(deleteApplianceCmd)
 
-	deleteApplianceCmd.Flags().StringP(flags.APPLIANCE_ID, flags.APPLIANCE_ID_SH, flags.ID_DFLT, "ID of memory appliance")
+	deleteApplianceCmd.Flags().StringP(flags.APPLIANCE_ID, flags.APPLIANCE_ID_SH, flags.ID_DFLT, "ID of memory appliance\n")
+	deleteApplianceCmd.MarkFlagRequired(flags.APPLIANCE_ID)
 
 	//Add command to parent
 	deleteCmd.AddCommand(deleteApplianceCmd)
+}
+
+// GetCmdUsageDeleteAppliance - Generates the command usage string for the cobra.Command.Use field.
+func GetCmdUsageDeleteAppliance() string {
+	return fmt.Sprintf("%s %s %s",
+		flags.APPLIANCE, // Note: The first word in the Command.Use string is how Cobra defines the "name" of this "command".
+		flags.GetOptionUsageGroupServiceTcp(false),
+		flags.GetOptionUsageApplianceId(false))
+}
+
+// GetCmdExampleDeleteAppliance - Generates the command example string for the cobra.Command.Example field.
+func GetCmdExampleDeleteAppliance() string {
+	baseCmd := fmt.Sprintf("cfm delete %s", flags.APPLIANCE)
+
+	shorthandFormat := fmt.Sprintf("%s %s %s",
+		baseCmd,
+		flags.GetOptionExampleShGroupServiceTcp(),
+		flags.GetOptionExampleShApplianceId())
+
+	longhandFormat := fmt.Sprintf("%s %s %s",
+		baseCmd,
+		flags.GetOptionExampleLhGroupServiceTcp(),
+		flags.GetOptionExampleLhApplianceId())
+
+	return fmt.Sprintf(`
+	%s
+
+	%s`, shorthandFormat, longhandFormat)
 }

--- a/cmd/cfm-cli/cmd/deleteBlade.go
+++ b/cmd/cfm-cli/cmd/deleteBlade.go
@@ -5,19 +5,17 @@ package cmd
 import (
 	"cfm/cli/pkg/serviceLib/flags"
 	"cfm/cli/pkg/serviceLib/serviceRequests"
+	"fmt"
 
 	"github.com/spf13/cobra"
 )
 
 var deleteBladeCmd = &cobra.Command{
-	Use:   `blade  [--serv-ip | -a] [--serv-net-port | -p] <--appliance-id | -L> <--blade-id | -B>`,
-	Short: "Delete a memory appliance blade connection from cfm-service",
-	Long:  `Deletes a netowrk connection from the cfm-service to an external memory appliance blade.`,
-	Example: `
-	cfm delete blade --appliance-id applId --blade-id bladeId --serv-ip 127.0.0.1 --serv-net-port 8080
-
-	cfm delete blade -L applId -B bladeId -a 127.0.0.1 -p 8080`,
-	Args: cobra.MatchAll(cobra.NoArgs),
+	Use:     GetCmdUsageDeleteBlade(),
+	Short:   "Delete a memory appliance blade connection from cfm-service",
+	Long:    `Deletes a netowrk connection from the cfm-service to an external memory appliance blade.`,
+	Example: GetCmdExampleDeleteBlade(),
+	Args:    cobra.MatchAll(cobra.NoArgs),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		initLogging(cmd)
 		return nil
@@ -39,9 +37,42 @@ func init() {
 
 	initCommonPersistentFlags(deleteBladeCmd)
 
-	deleteBladeCmd.Flags().StringP(flags.APPLIANCE_ID, flags.APPLIANCE_ID_SH, flags.ID_DFLT, "ID of blade's appliance")
-	deleteBladeCmd.Flags().StringP(flags.BLADE_ID, flags.BLADE_ID_SH, flags.ID_DFLT, "ID of blade to delete")
+	deleteBladeCmd.Flags().StringP(flags.APPLIANCE_ID, flags.APPLIANCE_ID_SH, flags.ID_DFLT, "ID of blade's appliance\n")
+	deleteBladeCmd.MarkFlagRequired(flags.APPLIANCE_ID)
+	deleteBladeCmd.Flags().StringP(flags.BLADE_ID, flags.BLADE_ID_SH, flags.ID_DFLT, "ID of blade to delete\n")
+	deleteBladeCmd.MarkFlagRequired(flags.BLADE_ID)
 
 	//Add command to parent
 	deleteCmd.AddCommand(deleteBladeCmd)
+}
+
+// GetCmdUsageDeleteBlade - Generates the command usage string for the cobra.Command.Use field.
+func GetCmdUsageDeleteBlade() string {
+	return fmt.Sprintf("%s %s %s %s",
+		flags.BLADE, // Note: The first word in the Command.Use string is how Cobra defines the "name" of this "command".
+		flags.GetOptionUsageGroupServiceTcp(false),
+		flags.GetOptionUsageApplianceId(false),
+		flags.GetOptionUsageBladeId(false))
+}
+
+// GetCmdExampleDeleteBlade - Generates the command example string for the cobra.Command.Example field.
+func GetCmdExampleDeleteBlade() string {
+	baseCmd := fmt.Sprintf("cfm delete %s", flags.BLADE)
+
+	shorthandFormat := fmt.Sprintf("%s %s %s %s",
+		baseCmd,
+		flags.GetOptionExampleShGroupServiceTcp(),
+		flags.GetOptionExampleShApplianceId(),
+		flags.GetOptionExampleShBladeId())
+
+	longhandFormat := fmt.Sprintf("%s %s %s %s",
+		baseCmd,
+		flags.GetOptionExampleLhGroupServiceTcp(),
+		flags.GetOptionExampleLhApplianceId(),
+		flags.GetOptionExampleLhBladeId())
+
+	return fmt.Sprintf(`
+	%s
+
+	%s`, shorthandFormat, longhandFormat)
 }

--- a/cmd/cfm-cli/cmd/deleteHost.go
+++ b/cmd/cfm-cli/cmd/deleteHost.go
@@ -5,19 +5,17 @@ package cmd
 import (
 	"cfm/cli/pkg/serviceLib/flags"
 	"cfm/cli/pkg/serviceLib/serviceRequests"
+	"fmt"
 
 	"github.com/spf13/cobra"
 )
 
 var deleteHostCmd = &cobra.Command{
-	Use:   `host [--serv-ip | -i] [--serv-net-port | -p] <--host-id | -H>`,
-	Short: `Delete a cxl host connection from cfm-service`,
-	Long:  `Deletes a netowrk connection from the cfm-service to an external cxl host.`,
-	Example: `
-	cfm delete host --host-id hostId --serv-ip 127.0.0.1 --serv-net-port 8080
-
-	cfm delete host -H hostId -a 127.0.0.1 -p 8080`,
-	Args: cobra.MatchAll(cobra.NoArgs),
+	Use:     GetCmdUsageDeleteHost(),
+	Short:   `Delete a cxl host connection from cfm-service`,
+	Long:    `Deletes a netowrk connection from the cfm-service to an external cxl host.`,
+	Example: GetCmdExampleDeleteHost(),
+	Args:    cobra.MatchAll(cobra.NoArgs),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		initLogging(cmd)
 		return nil
@@ -39,8 +37,37 @@ func init() {
 
 	initCommonPersistentFlags(deleteHostCmd)
 
-	deleteHostCmd.Flags().StringP(flags.HOST_ID, flags.HOST_ID_SH, flags.ID_DFLT, "ID of CXL host")
+	deleteHostCmd.Flags().StringP(flags.HOST_ID, flags.HOST_ID_SH, flags.ID_DFLT, "ID of CXL host\n")
+	deleteHostCmd.MarkFlagRequired(flags.HOST_ID)
 
 	//Add command to parent
 	deleteCmd.AddCommand(deleteHostCmd)
+}
+
+// GetCmdUsageDeleteHost - Generates the command usage string for the cobra.Command.Use field.
+func GetCmdUsageDeleteHost() string {
+	return fmt.Sprintf("%s %s %s",
+		flags.HOST, // Note: The first word in the Command.Use string is how Cobra defines the "name" of this "command".
+		flags.GetOptionUsageGroupServiceTcp(false),
+		flags.GetOptionUsageHostId(false))
+}
+
+// GetCmdExampleDeleteHost - Generates the command example string for the cobra.Command.Example field.
+func GetCmdExampleDeleteHost() string {
+	baseCmd := fmt.Sprintf("cfm delete %s", flags.HOST)
+
+	shorthandFormat := fmt.Sprintf("%s %s %s",
+		baseCmd,
+		flags.GetOptionExampleShGroupServiceTcp(),
+		flags.GetOptionExampleShHostId())
+
+	longhandFormat := fmt.Sprintf("%s %s %s",
+		baseCmd,
+		flags.GetOptionExampleLhGroupServiceTcp(),
+		flags.GetOptionExampleLhHostId())
+
+	return fmt.Sprintf(`
+	%s
+
+	%s`, shorthandFormat, longhandFormat)
 }

--- a/cmd/cfm-cli/cmd/freeBlade.go
+++ b/cmd/cfm-cli/cmd/freeBlade.go
@@ -11,14 +11,11 @@ import (
 )
 
 var freeBladeCmd = &cobra.Command{
-	Use:   "blade [--serv-ip | -a] [--serv-net-port | -p] <--appliance-id | -L> <--blade-id | -B> <--memory-id | -i>",
-	Short: "Free an existing memory region on the specified memory appliance blade.",
-	Long:  `Free an existing memory region on the specified memory appliance blade.  The blade port will be unassigned and the memory region's resource blocks will be deallocated.`,
-	Example: `
-	cfm free --serv-ip 127.0.0.1 --serv-net-port 8080 --appliance-id applId --blade-id bladeId --memory-id memoryId
-
-	cfm free -a 127.0.0.1 -p 8080 -L applId -B bladeId -m memoryId`,
-	Args: cobra.MatchAll(cobra.NoArgs),
+	Use:     GetCmdUsageFreeBlade(),
+	Short:   "Free an existing memory region on the specified memory appliance blade.",
+	Long:    `Free an existing memory region on the specified memory appliance blade.  The blade port (if present) will be unassigned and the memory region's resource blocks will be deallocated.`,
+	Example: GetCmdExampleFreeBlade(),
+	Args:    cobra.MatchAll(cobra.NoArgs),
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("Free Memory...")
 
@@ -41,15 +38,49 @@ var freeBladeCmd = &cobra.Command{
 func init() {
 	freeBladeCmd.DisableFlagsInUseLine = true
 
-	freeBladeCmd.Flags().StringP(flags.APPLIANCE_ID, flags.APPLIANCE_ID_SH, flags.ID_DFLT, "ID of appliance to interrogate")
+	freeBladeCmd.Flags().StringP(flags.APPLIANCE_ID, flags.APPLIANCE_ID_SH, flags.ID_DFLT, "ID of appliance to interrogate\n")
 	freeBladeCmd.MarkFlagRequired(flags.APPLIANCE_ID)
-	freeBladeCmd.Flags().StringP(flags.BLADE_ID, flags.BLADE_ID_SH, flags.ID_DFLT, "ID of appliance blade to interrogate")
+	freeBladeCmd.Flags().StringP(flags.BLADE_ID, flags.BLADE_ID_SH, flags.ID_DFLT, "ID of appliance blade to interrogate\n")
 	freeBladeCmd.MarkFlagRequired(flags.BLADE_ID)
-	freeBladeCmd.Flags().StringP(flags.MEMORY_ID, flags.MEMORY_ID_SH, flags.ID_DFLT, "ID of a specific appliance blade memory region to free.")
+	freeBladeCmd.Flags().StringP(flags.MEMORY_ID, flags.MEMORY_ID_SH, flags.ID_DFLT, "ID of a specific appliance blade memory region to free\n")
 	freeBladeCmd.MarkFlagRequired(flags.MEMORY_ID)
 
 	initCommonPersistentFlags(freeBladeCmd)
 
 	//Add command to parent
 	freeCmd.AddCommand(freeBladeCmd)
+}
+
+// GetCmdUsageFreeBlade - Generates the command usage string for the cobra.Command.Use field.
+func GetCmdUsageFreeBlade() string {
+	return fmt.Sprintf("%s %s %s %s %s",
+		flags.BLADE, // Note: The first word in the Command.Use string is how Cobra defines the "name" of this "command".
+		flags.GetOptionUsageGroupServiceTcp(false),
+		flags.GetOptionUsageApplianceId(false),
+		flags.GetOptionUsageBladeId(false),
+		flags.GetOptionUsageMemoryId(false))
+}
+
+// GetCmdExampleFreeBlade - Generates the command example string for the cobra.Command.Example field.
+func GetCmdExampleFreeBlade() string {
+	baseCmd := fmt.Sprintf("cfm free %s", flags.BLADE)
+
+	shorthandFormat := fmt.Sprintf("%s %s %s %s %s",
+		baseCmd,
+		flags.GetOptionExampleShGroupServiceTcp(),
+		flags.GetOptionExampleShApplianceId(),
+		flags.GetOptionExampleShBladeId(),
+		flags.GetOptionExampleShMemoryId())
+
+	longhandFormat := fmt.Sprintf("%s %s %s %s %s",
+		baseCmd,
+		flags.GetOptionExampleLhGroupServiceTcp(),
+		flags.GetOptionExampleLhApplianceId(),
+		flags.GetOptionExampleLhBladeId(),
+		flags.GetOptionExampleLhMemoryId())
+
+	return fmt.Sprintf(`
+	%s
+
+	%s`, shorthandFormat, longhandFormat)
 }

--- a/cmd/cfm-cli/cmd/list.go
+++ b/cmd/cfm-cli/cmd/list.go
@@ -31,8 +31,8 @@ func initCommonBladeListCmdFlags(cmd *cobra.Command) {
 
 	initCommonPersistentFlags(cmd)
 
-	cmd.Flags().StringP(flags.APPLIANCE_ID, flags.APPLIANCE_ID_SH, flags.ID_DFLT, "ID of appliance to interrogate")
-	cmd.Flags().StringP(flags.BLADE_ID, flags.BLADE_ID_SH, flags.ID_DFLT, "ID of blade to interrogate")
+	cmd.Flags().StringP(flags.APPLIANCE_ID, flags.APPLIANCE_ID_SH, flags.ID_DFLT, "ID of appliance to interrogate\n (default \"all appliances listed\")")
+	cmd.Flags().StringP(flags.BLADE_ID, flags.BLADE_ID_SH, flags.ID_DFLT, "ID of blade to interrogate\n (default \"all blades listed\")")
 }
 
 // Add set of flags used by all the "list" commands
@@ -42,5 +42,5 @@ func initCommonHostListCmdFlags(cmd *cobra.Command) {
 
 	initCommonPersistentFlags(cmd)
 
-	cmd.Flags().StringP(flags.HOST_ID, flags.HOST_ID_SH, flags.ID_DFLT, "ID of appliance to interrogate")
+	cmd.Flags().StringP(flags.HOST_ID, flags.HOST_ID_SH, flags.ID_DFLT, "ID of appliance to interrogate\n (default \"all hosts listed\")")
 }

--- a/cmd/cfm-cli/cmd/listAppliances.go
+++ b/cmd/cfm-cli/cmd/listAppliances.go
@@ -3,20 +3,19 @@
 package cmd
 
 import (
+	"cfm/cli/pkg/serviceLib/flags"
 	"cfm/cli/pkg/serviceLib/serviceRequests"
+	"fmt"
 
 	"github.com/spf13/cobra"
 )
 
 var listAppliancesCmd = &cobra.Command{
-	Use:   `appliances [--serv-ip | -i] [--serv-net-port | -p]`,
-	Short: "List all recognized memory appliance(s)",
-	Long:  `Queries the cfm-service for all recognized memory appliance(s) and outputs a summary to stdout.`,
-	Example: `
-	cfm list appliances --serv-ip 127.0.0.1 --serv-net-port 8080
-
-	cfm list appliances -a 127.0.0.1 -p 8080`,
-	Args: cobra.MatchAll(cobra.NoArgs),
+	Use:     GetCmdUsageListAppliances(),
+	Short:   "List all recognized memory appliance(s)",
+	Long:    `Queries the cfm-service for all recognized memory appliance(s) and outputs a summary to stdout.`,
+	Example: GetCmdExampleListAppliances(),
+	Args:    cobra.MatchAll(cobra.NoArgs),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		initLogging(cmd)
 		return nil
@@ -41,4 +40,29 @@ func init() {
 
 	//Add command to parent
 	listCmd.AddCommand(listAppliancesCmd)
+}
+
+// GetCmdUsageListAppliances - Generates the command usage string for the cobra.Command.Use field.
+func GetCmdUsageListAppliances() string {
+	return fmt.Sprintf("%s %s",
+		flags.APPLIANCES, // Note: The first word in the Command.Use string is how Cobra defines the "name" of this "command".
+		flags.GetOptionUsageGroupServiceTcp(false))
+}
+
+// GetCmdExampleListAppliances - Generates the command example string for the cobra.Command.Example field.
+func GetCmdExampleListAppliances() string {
+	baseCmd := fmt.Sprintf("cfm list %s", flags.APPLIANCES)
+
+	shorthandFormat := fmt.Sprintf("%s %s",
+		baseCmd,
+		flags.GetOptionExampleShGroupServiceTcp())
+
+	longhandFormat := fmt.Sprintf("%s %s",
+		baseCmd,
+		flags.GetOptionExampleLhGroupServiceTcp())
+
+	return fmt.Sprintf(`
+	%s
+
+	%s`, shorthandFormat, longhandFormat)
 }

--- a/cmd/cfm-cli/cmd/listBladePorts.go
+++ b/cmd/cfm-cli/cmd/listBladePorts.go
@@ -5,35 +5,22 @@ package cmd
 import (
 	"cfm/cli/pkg/serviceLib/flags"
 	"cfm/cli/pkg/serviceLib/serviceRequests"
+	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
 
 var listBladesPortsCmd = &cobra.Command{
-	Use:   `ports [--serv-ip | -a] [--serv-net-port | -p] [--appliance-id | -L] [--blade-id | -B] [--port-id | -o]`,
+	Use:   GetCmdUsageListBladesPorts(),
 	Short: "List all available blade ports",
 	Long: `Queries the cfm-service for available appliance blade ports.
 	Outputs a detailed summary of those ports to stdout.
-	Note that, for any given item ID, if it is omitted, ALL items are collected\searched.`,
-	Example: `
-	cfm list blades ports --serv-ip 127.0.0.1 --serv-net-port 8080 --appliance-id applId --blade-id bladeId --port-id portId
-	cfm list blades ports --serv-ip 127.0.0.1 --serv-net-port 8080 --appliance-id applId --blade-id bladeId
-	cfm list blades ports --serv-ip 127.0.0.1 --serv-net-port 8080 --appliance-id applId --port-id portId
-	cfm list blades ports --serv-ip 127.0.0.1 --serv-net-port 8080 --appliance-id applId
-	cfm list blades ports --serv-ip 127.0.0.1 --serv-net-port 8080 --blade-id bladeId --port-id portId
-	cfm list blades ports --serv-ip 127.0.0.1 --serv-net-port 8080 --blade-id bladeId
-	cfm list blades ports --serv-ip 127.0.0.1 --serv-net-port 8080 --port-id portId
-	cfm list blades ports --serv-ip 127.0.0.1 --serv-net-port 8080
-
-	cfm list blades ports -a 127.0.0.1 -p 8080 -L applId -B bladeId -o portId
-	cfm list blades ports -a 127.0.0.1 -p 8080 -L applId -B bladeId
-	cfm list blades ports -a 127.0.0.1 -p 8080 -L applId -o portId
-	cfm list blades ports -a 127.0.0.1 -p 8080 -L applId
-	cfm list blades ports -a 127.0.0.1 -p 8080 -B bladeId -o portId
-	cfm list blades ports -a 127.0.0.1 -p 8080 -B bladeId
-	cfm list blades ports -a 127.0.0.1 -p 8080 -o portId
-	cfm list blades ports -a 127.0.0.1 -p 8080 `,
-	Args: cobra.MatchAll(cobra.NoArgs),
+	Note: For any given ID option:
+			If the option is included, ONLY THAT ID is searched.
+			If the option is omitted, ALL POSSIBLE IDs (within cfm-service) are searched.`,
+	Example: GetCmdExampleListBladesPorts(),
+	Args:    cobra.MatchAll(cobra.NoArgs),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		initLogging(cmd)
 		return nil
@@ -53,10 +40,90 @@ var listBladesPortsCmd = &cobra.Command{
 func init() {
 	listBladesPortsCmd.DisableFlagsInUseLine = true
 
-	listBladesPortsCmd.Flags().StringP(flags.PORT_ID, flags.PORT_ID_SH, flags.ID_DFLT, "ID of a specific port. (default \"all ports returned.\")")
+	listBladesPortsCmd.Flags().StringP(flags.PORT_ID, flags.PORT_ID_SH, flags.ID_DFLT, "ID of a specific port\n (default \"all ports listed.\")")
 
 	initCommonBladeListCmdFlags(listBladesPortsCmd)
 
 	//Add command to parent
 	listBladesCmd.AddCommand(listBladesPortsCmd)
+}
+
+// GetCmdUsageListBladesPorts - Generates the command usage string for the cobra.Command.Use field.
+func GetCmdUsageListBladesPorts() string {
+	return fmt.Sprintf("%s %s %s %s %s",
+		flags.PORTS, // Note: The first word in the Command.Use string is how Cobra defines the "name" of this "command".
+		flags.GetOptionUsageGroupServiceTcp(false),
+		flags.GetOptionUsageApplianceId(true),
+		flags.GetOptionUsageBladeId(true),
+		flags.GetOptionUsagePortId(true))
+}
+
+// GetCmdExampleListBladesPorts - Generates the command example string for the cobra.Command.Example field.
+func GetCmdExampleListBladesPorts() string {
+	baseCmd := fmt.Sprintf("cfm list %s %s", flags.BLADES, flags.PORTS)
+
+	baseCmdLoopSh := fmt.Sprintf("%s %s",
+		baseCmd,
+		flags.GetOptionExampleShGroupServiceTcp())
+
+	shIdExamplesMap := map[string]string{
+		"applianceId": " " + flags.GetOptionExampleShApplianceId(),
+		"bladeId":     " " + flags.GetOptionExampleShBladeId(),
+		"portId":      " " + flags.GetOptionExampleShPortId(),
+	}
+
+	shExampleLines := make([]string, 0, 8)
+	for i := 0; i < 8; i++ {
+		s := baseCmdLoopSh
+		if i&1 != 0 {
+			s += shIdExamplesMap["applianceId"]
+		}
+		if i&2 != 0 {
+			s += shIdExamplesMap["bladeId"]
+		}
+		if i&4 != 0 {
+			s += shIdExamplesMap["portId"]
+		}
+		shExampleLines = append(shExampleLines, s)
+	}
+
+	var shorthandFormat strings.Builder
+	for _, line := range shExampleLines {
+		shorthandFormat.WriteString("\t" + line + "\n")
+	}
+
+	baseCmdLoopLh := fmt.Sprintf("%s %s",
+		baseCmd,
+		flags.GetOptionExampleLhGroupServiceTcp())
+
+	lhIdExamplesMap := map[string]string{
+		"applianceId": " " + flags.GetOptionExampleLhApplianceId(),
+		"bladeId":     " " + flags.GetOptionExampleLhBladeId(),
+		"portId":      " " + flags.GetOptionExampleLhPortId(),
+	}
+
+	lhExampleLines := make([]string, 0, 8)
+	for i := 0; i < 8; i++ {
+		s := baseCmdLoopLh
+		if i&1 != 0 {
+			s += lhIdExamplesMap["applianceId"]
+		}
+		if i&2 != 0 {
+			s += lhIdExamplesMap["bladeId"]
+		}
+		if i&4 != 0 {
+			s += lhIdExamplesMap["portId"]
+		}
+		lhExampleLines = append(lhExampleLines, s)
+	}
+
+	var longhandFormat strings.Builder
+	for _, line := range lhExampleLines {
+		longhandFormat.WriteString("\t" + line + "\n")
+	}
+
+	return fmt.Sprintf(`
+%s
+
+%s`, shorthandFormat.String(), longhandFormat.String())
 }

--- a/cmd/cfm-cli/cmd/listBladeResources.go
+++ b/cmd/cfm-cli/cmd/listBladeResources.go
@@ -5,35 +5,21 @@ package cmd
 import (
 	"cfm/cli/pkg/serviceLib/flags"
 	"cfm/cli/pkg/serviceLib/serviceRequests"
+	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
 
 var listBladeResourcesCmd = &cobra.Command{
-	Use:   `resources [--serv-ip | -a] [--serv-net-port | -p] [--appliance-id | -L] [--blade-id | -B] [--resource-id | -i]`,
+	Use:   GetCmdUsageListBladesResources(),
 	Short: "List all available blade memory resources",
 	Long: `Queries the cfm-service for existing memory resources.
 	Outputs a detailed summary (including composition state) of those resources to stdout.
-	Note that, for any given item ID, if it is omitted, ALL items are collected\searched.`,
-	Example: `
-	cfm list blades resources --serv-ip 127.0.0.1 --serv-net-port 8080 --appliance-id applId --blade-id bladeId --resource-id resId
-	cfm list blades resources --serv-ip 127.0.0.1 --serv-net-port 8080 --appliance-id applId --blade-id bladeId
-	cfm list blades resources --serv-ip 127.0.0.1 --serv-net-port 8080 --appliance-id applId --resource-id resId
-	cfm list blades resources --serv-ip 127.0.0.1 --serv-net-port 8080 --appliance-id applId
-	cfm list blades resources --serv-ip 127.0.0.1 --serv-net-port 8080 --blade-id bladeId --resource-id resId
-	cfm list blades resources --serv-ip 127.0.0.1 --serv-net-port 8080 --blade-id bladeId
-	cfm list blades resources --serv-ip 127.0.0.1 --serv-net-port 8080 --resource-id resId
-	cfm list blades resources --serv-ip 127.0.0.1 --serv-net-port 8080
-
-	cfm list blades resources -a 127.0.0.1 -p 8080 -L applId -B bladeId -r resId
-	cfm list blades resources -a 127.0.0.1 -p 8080 -L applId -B bladeId
-	cfm list blades resources -a 127.0.0.1 -p 8080 -L applId -r resId
-	cfm list blades resources -a 127.0.0.1 -p 8080 -L applId
-	cfm list blades resources -a 127.0.0.1 -p 8080 -B bladeId -r resId
-	cfm list blades resources -a 127.0.0.1 -p 8080 -B bladeId
-	cfm list blades resources -a 127.0.0.1 -p 8080 -r resId
-	cfm list blades resources -a 127.0.0.1 -p 8080 `,
-	Args: cobra.MatchAll(cobra.NoArgs),
+	Note: For any given ID option:
+			If the option is included, ONLY THAT ID is searched.
+			If the option is omitted, ALL POSSIBLE IDs (within cfm-service) are searched.`,
+	Example: GetCmdExampleListBladesResources(),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		initLogging(cmd)
 		return nil
@@ -53,10 +39,90 @@ var listBladeResourcesCmd = &cobra.Command{
 func init() {
 	listBladeResourcesCmd.DisableFlagsInUseLine = true
 
-	listBladeResourcesCmd.Flags().StringP(flags.RESOURCE_ID, flags.RESOURCE_ID_SH, flags.ID_DFLT, "ID of a specific resource block. (default \"all resource blocks returned\")")
+	listBladeResourcesCmd.Flags().StringP(flags.RESOURCE_ID, flags.RESOURCE_ID_SH, flags.ID_DFLT, "ID of a specific resource block\n (default \"all resource blocks listed\")")
 
 	initCommonBladeListCmdFlags(listBladeResourcesCmd)
 
 	//Add command to parent
 	listBladesCmd.AddCommand(listBladeResourcesCmd)
+}
+
+// GetCmdUsageListBladeResources - Generates the command usage string for the cobra.Command.Use field.
+func GetCmdUsageListBladesResources() string {
+	return fmt.Sprintf("%s %s %s %s %s",
+		flags.RESOURCES, // Note: The first word in the Command.Use string is how Cobra defines the "name" of this "command".
+		flags.GetOptionUsageGroupServiceTcp(false),
+		flags.GetOptionUsageApplianceId(true),
+		flags.GetOptionUsageBladeId(true),
+		flags.GetOptionUsageResourceId(true))
+}
+
+// GetCmdExampleListBladesResources - Generates the command example string for the cobra.Command.Example field.
+func GetCmdExampleListBladesResources() string {
+	baseCmd := fmt.Sprintf("cfm list %s %s", flags.BLADES, flags.RESOURCES)
+
+	baseCmdLoopSh := fmt.Sprintf("%s %s",
+		baseCmd,
+		flags.GetOptionExampleShGroupServiceTcp())
+
+	shIdExamplesMap := map[string]string{
+		"applianceId": " " + flags.GetOptionExampleShApplianceId(),
+		"bladeId":     " " + flags.GetOptionExampleShBladeId(),
+		"resourceId":  " " + flags.GetOptionExampleShResourceId(),
+	}
+
+	shExampleLines := make([]string, 0, 8)
+	for i := 0; i < 8; i++ {
+		s := baseCmdLoopSh
+		if i&1 != 0 {
+			s += shIdExamplesMap["applianceId"]
+		}
+		if i&2 != 0 {
+			s += shIdExamplesMap["bladeId"]
+		}
+		if i&4 != 0 {
+			s += shIdExamplesMap["resourceId"]
+		}
+		shExampleLines = append(shExampleLines, s)
+	}
+
+	var shorthandFormat strings.Builder
+	for _, line := range shExampleLines {
+		shorthandFormat.WriteString("\t" + line + "\n")
+	}
+
+	baseCmdLoopLh := fmt.Sprintf("%s %s",
+		baseCmd,
+		flags.GetOptionExampleLhGroupServiceTcp())
+
+	lhIdExamplesMap := map[string]string{
+		"applianceId": " " + flags.GetOptionExampleLhApplianceId(),
+		"bladeId":     " " + flags.GetOptionExampleLhBladeId(),
+		"resourceId":  " " + flags.GetOptionExampleLhResourceId(),
+	}
+
+	lhExampleLines := make([]string, 0, 8)
+	for i := 0; i < 8; i++ {
+		s := baseCmdLoopLh
+		if i&1 != 0 {
+			s += lhIdExamplesMap["applianceId"]
+		}
+		if i&2 != 0 {
+			s += lhIdExamplesMap["bladeId"]
+		}
+		if i&4 != 0 {
+			s += lhIdExamplesMap["resourceId"]
+		}
+		lhExampleLines = append(lhExampleLines, s)
+	}
+
+	var longhandFormat strings.Builder
+	for _, line := range lhExampleLines {
+		longhandFormat.WriteString("\t" + line + "\n")
+	}
+
+	return fmt.Sprintf(`
+%s
+
+%s`, shorthandFormat.String(), longhandFormat.String())
 }

--- a/cmd/cfm-cli/cmd/listHostMemoryDevices.go
+++ b/cmd/cfm-cli/cmd/listHostMemoryDevices.go
@@ -5,27 +5,22 @@ package cmd
 import (
 	"cfm/cli/pkg/serviceLib/flags"
 	"cfm/cli/pkg/serviceLib/serviceRequests"
+	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
 
 var listHostsMemoryDevicesCmd = &cobra.Command{
-	Use:   `memory-devices [--serv-ip | -a] [--serv-net-port | -p] [--host-id | -H] [--memory-device-id | -d]`,
+	Use:   GetCmdUsageListHostsMemoryDevices(),
 	Short: "List all available logical memory device(s) accessible to the host(s)",
 	Long: `Queries the cfm-service for logical memory device(s) accessible to the host(s).
 	Outputs a detailed summary of those memory regions to stdout.
-	Note that, for any given item ID, if it is omitted, ALL items are collected\searched.`,
-	Example: `
-	cfm list hosts memory-devices --serv-ip 127.0.0.1 --serv-net-port 8080 --host-id hostId --memory-device-id memdevId
-	cfm list hosts memory-devices --serv-ip 127.0.0.1 --serv-net-port 8080 --host-id hostId
-	cfm list hosts memory-devices --serv-ip 127.0.0.1 --serv-net-port 8080 --memory-device-id memdevId
-	cfm list hosts memory-devices --serv-ip 127.0.0.1 --serv-net-port 8080
-
-	cfm list hosts memory-devices -a 127.0.0.1 -p 8080 -B hostId -d memdevId
-	cfm list hosts memory-devices -a 127.0.0.1 -p 8080 -B hostId
-	cfm list hosts memory-devices -a 127.0.0.1 -p 8080 -d memdevId
-	cfm list hosts memory-devices -a 127.0.0.1 -p 8080 `,
-	Args: cobra.MatchAll(cobra.NoArgs),
+	Note: For any given ID option:
+			If the option is included, ONLY THAT ID is searched.
+			If the option is omitted, ALL POSSIBLE IDs (within cfm-service) are searched.`,
+	Example: GetCmdExampleListHostsMemoryDevices(),
+	Args:    cobra.MatchAll(cobra.NoArgs),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		initLogging(cmd)
 		return nil
@@ -47,8 +42,79 @@ func init() {
 
 	initCommonHostListCmdFlags(listHostsMemoryDevicesCmd)
 
-	listHostsMemoryDevicesCmd.Flags().StringP(flags.MEMORY_DEVICE_ID, flags.MEMORY_DEVICE_ID_SH, flags.ID_DFLT, "ID of a specific memory device. (default \"all memory devices returned\")")
+	listHostsMemoryDevicesCmd.Flags().StringP(flags.MEMORY_DEVICE_ID, flags.MEMORY_DEVICE_ID_SH, flags.ID_DFLT, "ID of a specific memory device\n (default \"all memory devices listsed\")")
 
 	//Add command to parent
 	listHostsCmd.AddCommand(listHostsMemoryDevicesCmd)
+}
+
+// GetCmdUsageListHostsMemoryDevices - Generates the command usage string for the cobra.Command.Use field.
+func GetCmdUsageListHostsMemoryDevices() string {
+	return fmt.Sprintf("%s %s %s %s",
+		flags.MEMORY_DEVICES, // Note: The first word in the Command.Use string is how Cobra defines the "name" of this "command".
+		flags.GetOptionUsageGroupServiceTcp(false),
+		flags.GetOptionUsageHostId(true),
+		flags.GetOptionUsageMemoryDeviceId(true))
+}
+
+// GetCmdExampleListHostsMemoryDevices - Generates the command example string for the cobra.Command.Example field.
+func GetCmdExampleListHostsMemoryDevices() string {
+	baseCmd := fmt.Sprintf("cfm list %s %s", flags.HOSTS, flags.MEMORY_DEVICES)
+
+	baseCmdLoopSh := fmt.Sprintf("%s %s",
+		baseCmd,
+		flags.GetOptionExampleShGroupServiceTcp())
+
+	shIdExamplesMap := map[string]string{
+		"hostId":         " " + flags.GetOptionExampleShHostId(),
+		"memorydeviceId": " " + flags.GetOptionExampleShMemoryDeviceId(),
+	}
+
+	shExampleLines := make([]string, 0, 4)
+	for i := 0; i < 4; i++ {
+		s := baseCmdLoopSh
+		if i&1 != 0 {
+			s += shIdExamplesMap["hostId"]
+		}
+		if i&2 != 0 {
+			s += shIdExamplesMap["memorydeviceId"]
+		}
+		shExampleLines = append(shExampleLines, s)
+	}
+
+	var shorthandFormat strings.Builder
+	for _, line := range shExampleLines {
+		shorthandFormat.WriteString("\t" + line + "\n")
+	}
+
+	baseCmdLoopLh := fmt.Sprintf("%s %s",
+		baseCmd,
+		flags.GetOptionExampleLhGroupServiceTcp())
+
+	lhIdExamplesMap := map[string]string{
+		"hostId":         " " + flags.GetOptionExampleLhHostId(),
+		"memorydeviceId": " " + flags.GetOptionExampleLhMemoryDeviceId(),
+	}
+
+	lhExampleLines := make([]string, 0, 4)
+	for i := 0; i < 4; i++ {
+		s := baseCmdLoopLh
+		if i&1 != 0 {
+			s += lhIdExamplesMap["hostId"]
+		}
+		if i&2 != 0 {
+			s += lhIdExamplesMap["memorydeviceId"]
+		}
+		lhExampleLines = append(lhExampleLines, s)
+	}
+
+	var longhandFormat strings.Builder
+	for _, line := range lhExampleLines {
+		longhandFormat.WriteString("\t" + line + "\n")
+	}
+
+	return fmt.Sprintf(`
+%s
+
+%s`, shorthandFormat.String(), longhandFormat.String())
 }

--- a/cmd/cfm-cli/cmd/listHostPorts.go
+++ b/cmd/cfm-cli/cmd/listHostPorts.go
@@ -5,27 +5,22 @@ package cmd
 import (
 	"cfm/cli/pkg/serviceLib/flags"
 	"cfm/cli/pkg/serviceLib/serviceRequests"
+	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
 
 var listHostsPortsCmd = &cobra.Command{
-	Use:   `ports [--serv-ip | -a] [--serv-net-port | -p] [-host-id | -H] [--port-id | -o]`,
+	Use:   GetCmdUsageListHostsPorts(),
 	Short: "List all available port(s) accessible to the host(s).",
 	Long: `Queries the cfm-service for port(s) accessible to the host(s).
 	Outputs a detailed summary of those ports to stdout.
-	Note that, for any given item ID, if it is omitted, ALL items are collected\searched.`,
-	Example: `
-	cfm list hosts ports --serv-ip 127.0.0.1 --serv-net-port 8080 --host-id hostId --port-id portId
-	cfm list hosts ports --serv-ip 127.0.0.1 --serv-net-port 8080 --host-id hostId
-	cfm list hosts ports --serv-ip 127.0.0.1 --serv-net-port 8080 --port-id portId
-	cfm list hosts ports --serv-ip 127.0.0.1 --serv-net-port 8080
-
-	cfm list hosts ports -a 127.0.0.1 -p 8080 -B hostId -o portId
-	cfm list hosts ports -a 127.0.0.1 -p 8080 -B hostId
-	cfm list hosts ports -a 127.0.0.1 -p 8080 -o portId
-	cfm list hosts ports -a 127.0.0.1 -p 8080 `,
-	Args: cobra.MatchAll(cobra.NoArgs),
+	Note: For any given ID option:
+			If the option is included, ONLY THAT ID is searched.
+			If the option is omitted, ALL POSSIBLE IDs (within cfm-service) are searched.`,
+	Example: GetCmdExampleListHostsPorts(),
+	Args:    cobra.MatchAll(cobra.NoArgs),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		initLogging(cmd)
 		return nil
@@ -47,8 +42,79 @@ func init() {
 
 	initCommonHostListCmdFlags(listHostsPortsCmd)
 
-	listHostsPortsCmd.Flags().StringP(flags.PORT_ID, flags.PORT_ID_SH, flags.ID_DFLT, "ID of a specific port. (default \"all ports returned.\")")
+	listHostsPortsCmd.Flags().StringP(flags.PORT_ID, flags.PORT_ID_SH, flags.ID_DFLT, "ID of a specific port\n (default \"all ports listed.\")")
 
 	//Add command to parent
 	listHostsCmd.AddCommand(listHostsPortsCmd)
+}
+
+// GetCmdUsageListHostsPorts - Generates the command usage string for the cobra.Command.Use field.
+func GetCmdUsageListHostsPorts() string {
+	return fmt.Sprintf("%s %s %s %s",
+		flags.PORTS, // Note: The first word in the Command.Use string is how Cobra defines the "name" of this "command".
+		flags.GetOptionUsageGroupServiceTcp(false),
+		flags.GetOptionUsageHostId(true),
+		flags.GetOptionUsagePortId(true))
+}
+
+// GetCmdExampleListHostsPorts - Generates the command example string for the cobra.Command.Example field.
+func GetCmdExampleListHostsPorts() string {
+	baseCmd := fmt.Sprintf("cfm list %s %s", flags.HOSTS, flags.PORTS)
+
+	baseCmdLoopSh := fmt.Sprintf("%s %s",
+		baseCmd,
+		flags.GetOptionExampleShGroupServiceTcp())
+
+	shIdExamplesMap := map[string]string{
+		"hostId": " " + flags.GetOptionExampleShHostId(),
+		"portId": " " + flags.GetOptionExampleShPortId(),
+	}
+
+	shExampleLines := make([]string, 0, 4)
+	for i := 0; i < 4; i++ {
+		s := baseCmdLoopSh
+		if i&1 != 0 {
+			s += shIdExamplesMap["hostId"]
+		}
+		if i&2 != 0 {
+			s += shIdExamplesMap["portId"]
+		}
+		shExampleLines = append(shExampleLines, s)
+	}
+
+	var shorthandFormat strings.Builder
+	for _, line := range shExampleLines {
+		shorthandFormat.WriteString("\t" + line + "\n")
+	}
+
+	baseCmdLoopLh := fmt.Sprintf("%s %s",
+		baseCmd,
+		flags.GetOptionExampleLhGroupServiceTcp())
+
+	lhIdExamplesMap := map[string]string{
+		"hostId": " " + flags.GetOptionExampleLhHostId(),
+		"portId": " " + flags.GetOptionExampleLhPortId(),
+	}
+
+	lhExampleLines := make([]string, 0, 4)
+	for i := 0; i < 4; i++ {
+		s := baseCmdLoopLh
+		if i&1 != 0 {
+			s += lhIdExamplesMap["hostId"]
+		}
+		if i&2 != 0 {
+			s += lhIdExamplesMap["portId"]
+		}
+		lhExampleLines = append(lhExampleLines, s)
+	}
+
+	var longhandFormat strings.Builder
+	for _, line := range lhExampleLines {
+		longhandFormat.WriteString("\t" + line + "\n")
+	}
+
+	return fmt.Sprintf(`
+%s
+
+%s`, shorthandFormat.String(), longhandFormat.String())
 }

--- a/cmd/cfm-cli/cmd/listHosts.go
+++ b/cmd/cfm-cli/cmd/listHosts.go
@@ -3,21 +3,20 @@
 package cmd
 
 import (
+	"cfm/cli/pkg/serviceLib/flags"
 	"cfm/cli/pkg/serviceLib/serviceRequests"
+	"fmt"
 
 	"github.com/spf13/cobra"
 )
 
 // listHostsCmd represents the listHosts command
 var listHostsCmd = &cobra.Command{
-	Use:   `hosts [--serv-ip | -i] [--serv-net-port | -p]`,
-	Short: "List all recognized cxl host(s)",
-	Long:  `Queries the cfm-service for all recognized cxl host(s) and outputs a summary to stdout.`,
-	Example: `
-	cfm list hosts --serv-ip 127.0.0.1 --serv-net-port 8080
-
-	cfm list hosts -a 127.0.0.1 -p 8080`,
-	Args: cobra.MatchAll(cobra.NoArgs),
+	Use:     GetCmdUsageListHosts(),
+	Short:   "List all recognized cxl host(s)",
+	Long:    `Queries the cfm-service for all recognized cxl host(s) and outputs a summary to stdout.`,
+	Example: GetCmdExampleListHosts(),
+	Args:    cobra.MatchAll(cobra.NoArgs),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		initLogging(cmd)
 		return nil
@@ -42,4 +41,29 @@ func init() {
 
 	//Add command to parent
 	listCmd.AddCommand(listHostsCmd)
+}
+
+// GetCmdUsageListHost - Generates the command usage string for the cobra.Command.Use field.
+func GetCmdUsageListHosts() string {
+	return fmt.Sprintf("%s %s",
+		flags.HOSTS, // Note: The first word in the Command.Use string is how Cobra defines the "name" of this "command".
+		flags.GetOptionUsageGroupServiceTcp(false))
+}
+
+// GetCmdExampleListHosts - Generates the command example string for the cobra.Command.Example field.
+func GetCmdExampleListHosts() string {
+	baseCmd := fmt.Sprintf("cfm list %s", flags.HOSTS)
+
+	shorthandFormat := fmt.Sprintf("%s %s",
+		baseCmd,
+		flags.GetOptionExampleShGroupServiceTcp())
+
+	longhandFormat := fmt.Sprintf("%s %s",
+		baseCmd,
+		flags.GetOptionExampleLhGroupServiceTcp())
+
+	return fmt.Sprintf(`
+	%s
+
+	%s`, shorthandFormat, longhandFormat)
 }

--- a/cmd/cfm-cli/cmd/renameAppliance.go
+++ b/cmd/cfm-cli/cmd/renameAppliance.go
@@ -5,19 +5,17 @@ package cmd
 import (
 	"cfm/cli/pkg/serviceLib/flags"
 	"cfm/cli/pkg/serviceLib/serviceRequests"
+	"fmt"
 
 	"github.com/spf13/cobra"
 )
 
 var renameApplianceCmd = &cobra.Command{
-	Use:   `appliance [--serv-ip | -a] [--serv-net-port | -p] <--appliance-id | -L> <--new-id | -N>`,
-	Short: "Rename a specific composable memory appliance (CMA) to a new ID",
-	Long:  `Rename a specific composable memory appliance (CMA) to a new ID.`,
-	Example: `
-	cfm rename appliance --appliance-id applId --new-id newId --serv-ip 127.0.0.1 --serv-net-port 8080
-
-	cfm rename appliance -L applId -N newId -a 127.0.0.1 -p 8080`,
-	Args: cobra.MatchAll(cobra.NoArgs),
+	Use:     GetCmdUsageRenameAppliance(),
+	Short:   "Rename a specific composable memory appliance (CMA) to a new ID",
+	Long:    `Rename a specific composable memory appliance (CMA) to a new ID.`,
+	Example: GetCmdExampleRenameAppliance(),
+	Args:    cobra.MatchAll(cobra.NoArgs),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		initLogging(cmd)
 		return nil
@@ -39,11 +37,42 @@ func init() {
 
 	initCommonPersistentFlags(renameApplianceCmd)
 
-	renameApplianceCmd.Flags().StringP(flags.APPLIANCE_ID, flags.APPLIANCE_ID_SH, flags.ID_DFLT, "Current ID of composable memory appliance (CMA)")
+	renameApplianceCmd.Flags().StringP(flags.APPLIANCE_ID, flags.APPLIANCE_ID_SH, flags.ID_DFLT, "Current ID of composable memory appliance (CMA)\n")
 	renameApplianceCmd.MarkFlagRequired(flags.APPLIANCE_ID)
-	renameApplianceCmd.Flags().StringP(flags.NEW_ID, flags.NEW_ID_SH, flags.ID_DFLT, "New ID of composable memory appliance (CMA)")
+	renameApplianceCmd.Flags().StringP(flags.NEW_ID, flags.NEW_ID_SH, flags.ID_DFLT, "New ID of composable memory appliance (CMA)\n")
 	renameApplianceCmd.MarkFlagRequired(flags.NEW_ID)
 
 	//Add command to parent
 	renameCmd.AddCommand(renameApplianceCmd)
+}
+
+// GetCmdUsageRenameAppliance - Generates the command usage string for the cobra.Command.Use field.
+func GetCmdUsageRenameAppliance() string {
+	return fmt.Sprintf("%s %s %s %s",
+		flags.APPLIANCE, // Note: The first word in the Command.Use string is how Cobra defines the "name" of this "command".
+		flags.GetOptionUsageGroupServiceTcp(false),
+		flags.GetOptionUsageApplianceId(false),
+		flags.GetOptionUsageNewId(false))
+}
+
+// GetCmdExampleRenameAppliance - Generates the command example string for the cobra.Command.Example field.
+func GetCmdExampleRenameAppliance() string {
+	baseCmd := fmt.Sprintf("cfm rename %s", flags.APPLIANCE)
+
+	shorthandFormat := fmt.Sprintf("%s %s %s %s",
+		baseCmd,
+		flags.GetOptionExampleShGroupServiceTcp(),
+		flags.GetOptionExampleShApplianceId(),
+		flags.GetOptionExampleShNewId())
+
+	longhandFormat := fmt.Sprintf("%s %s %s %s",
+		baseCmd,
+		flags.GetOptionExampleLhGroupServiceTcp(),
+		flags.GetOptionExampleLhApplianceId(),
+		flags.GetOptionExampleLhNewId())
+
+	return fmt.Sprintf(`
+	%s
+
+	%s`, shorthandFormat, longhandFormat)
 }

--- a/cmd/cfm-cli/cmd/renameBlade.go
+++ b/cmd/cfm-cli/cmd/renameBlade.go
@@ -5,19 +5,17 @@ package cmd
 import (
 	"cfm/cli/pkg/serviceLib/flags"
 	"cfm/cli/pkg/serviceLib/serviceRequests"
+	"fmt"
 
 	"github.com/spf13/cobra"
 )
 
 var renameBladeCmd = &cobra.Command{
-	Use:   `blade  [--serv-ip | -a] [--serv-net-port | -p] <--appliance-id | -L> <--blade-id | -B> <--new-id | -N>`,
-	Short: "Rename a single blade ID on a specific composable memory appliance (CMA) to a new ID",
-	Long:  `Rename a single blade ID on a specific composable memory appliance (CMA) to a new ID.`,
-	Example: `
-	cfm rename blade --appliance-id applId --blade-id bladeId --new-id newId --serv-ip 127.0.0.1 --serv-net-port 8080
-
-	cfm rename blade -L applId -B bladeId -N newId -a 127.0.0.1 -p 8080`,
-	Args: cobra.MatchAll(cobra.NoArgs),
+	Use:     GetCmdUsageRenameBlade(),
+	Short:   "Rename a single blade ID on a specific composable memory appliance (CMA) to a new ID",
+	Long:    `Rename a single blade ID on a specific composable memory appliance (CMA) to a new ID.`,
+	Example: GetCmdExampleRenameBlade(),
+	Args:    cobra.MatchAll(cobra.NoArgs),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		initLogging(cmd)
 		return nil
@@ -39,13 +37,47 @@ func init() {
 
 	initCommonPersistentFlags(renameBladeCmd)
 
-	renameBladeCmd.Flags().StringP(flags.APPLIANCE_ID, flags.APPLIANCE_ID_SH, flags.ID_DFLT, "ID of blade's composable memory appliance (CMA)")
+	renameBladeCmd.Flags().StringP(flags.APPLIANCE_ID, flags.APPLIANCE_ID_SH, flags.ID_DFLT, "ID of blade's composable memory appliance (CMA)\n")
 	renameBladeCmd.MarkFlagRequired(flags.APPLIANCE_ID)
-	renameBladeCmd.Flags().StringP(flags.BLADE_ID, flags.BLADE_ID_SH, flags.ID_DFLT, "Current blade ID")
+	renameBladeCmd.Flags().StringP(flags.BLADE_ID, flags.BLADE_ID_SH, flags.ID_DFLT, "Current blade ID\n")
 	renameBladeCmd.MarkFlagRequired(flags.BLADE_ID)
-	renameBladeCmd.Flags().StringP(flags.NEW_ID, flags.NEW_ID_SH, flags.ID_DFLT, "New blade ID")
+	renameBladeCmd.Flags().StringP(flags.NEW_ID, flags.NEW_ID_SH, flags.ID_DFLT, "New blade ID\n")
 	renameBladeCmd.MarkFlagRequired(flags.NEW_ID)
 
 	//Add command to parent
 	renameCmd.AddCommand(renameBladeCmd)
+}
+
+// GetCmdUsageRenameBlade - Generates the command usage string for the cobra.Command.Use field.
+func GetCmdUsageRenameBlade() string {
+	return fmt.Sprintf("%s %s %s %s %s",
+		flags.BLADE, // Note: The first word in the Command.Use string is how Cobra defines the "name" of this "command".
+		flags.GetOptionUsageGroupServiceTcp(false),
+		flags.GetOptionUsageApplianceId(false),
+		flags.GetOptionUsageBladeId(false),
+		flags.GetOptionUsageNewId(false))
+}
+
+// GetCmdExampleRenameBlade - Generates the command example string for the cobra.Command.Example field.
+func GetCmdExampleRenameBlade() string {
+	baseCmd := fmt.Sprintf("cfm rename %s", flags.BLADE)
+
+	shorthandFormat := fmt.Sprintf("%s %s %s %s %s",
+		baseCmd,
+		flags.GetOptionExampleShGroupServiceTcp(),
+		flags.GetOptionExampleShApplianceId(),
+		flags.GetOptionExampleShBladeId(),
+		flags.GetOptionExampleShNewId())
+
+	longhandFormat := fmt.Sprintf("%s %s %s %s %s",
+		baseCmd,
+		flags.GetOptionExampleLhGroupServiceTcp(),
+		flags.GetOptionExampleLhApplianceId(),
+		flags.GetOptionExampleLhBladeId(),
+		flags.GetOptionExampleLhNewId())
+
+	return fmt.Sprintf(`
+	%s
+
+	%s`, shorthandFormat, longhandFormat)
 }

--- a/cmd/cfm-cli/cmd/renameHost.go
+++ b/cmd/cfm-cli/cmd/renameHost.go
@@ -5,19 +5,17 @@ package cmd
 import (
 	"cfm/cli/pkg/serviceLib/flags"
 	"cfm/cli/pkg/serviceLib/serviceRequests"
+	"fmt"
 
 	"github.com/spf13/cobra"
 )
 
 var renameHostCmd = &cobra.Command{
-	Use:   `host [--serv-ip | -i] [--serv-net-port | -p] <--host-id | -H> <--new-id | -N>`,
-	Short: `Rename a specific cxl host to a new ID`,
-	Long:  `Rename a specific cxl host to a new ID.`,
-	Example: `
-	cfm rename host --host-id hostId --new-id newId --serv-ip 127.0.0.1 --serv-net-port 8080
-
-	cfm rename host -H hostId -N newId -a 127.0.0.1 -p 8080`,
-	Args: cobra.MatchAll(cobra.NoArgs),
+	Use:     GetCmdUsageRenameHost(),
+	Short:   `Rename a specific cxl host to a new ID`,
+	Long:    `Rename a specific cxl host to a new ID.`,
+	Example: GetCmdExampleRenameHost(),
+	Args:    cobra.MatchAll(cobra.NoArgs),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		initLogging(cmd)
 		return nil
@@ -39,11 +37,42 @@ func init() {
 
 	initCommonPersistentFlags(renameHostCmd)
 
-	renameHostCmd.Flags().StringP(flags.HOST_ID, flags.HOST_ID_SH, flags.ID_DFLT, "Current CXL host ID")
+	renameHostCmd.Flags().StringP(flags.HOST_ID, flags.HOST_ID_SH, flags.ID_DFLT, "Current CXL host ID\n")
 	renameHostCmd.MarkFlagRequired(flags.HOST_ID)
-	renameHostCmd.Flags().StringP(flags.NEW_ID, flags.NEW_ID_SH, flags.ID_DFLT, "New CXL host ID")
+	renameHostCmd.Flags().StringP(flags.NEW_ID, flags.NEW_ID_SH, flags.ID_DFLT, "New CXL host ID\n")
 	renameHostCmd.MarkFlagRequired(flags.NEW_ID)
 
 	//Add command to parent
 	renameCmd.AddCommand(renameHostCmd)
+}
+
+// GetCmdUsageRenameHost - Generates the command usage string for the cobra.Command.Use field.
+func GetCmdUsageRenameHost() string {
+	return fmt.Sprintf("%s %s %s %s",
+		flags.HOST, // Note: The first word in the Command.Use string is how Cobra defines the "name" of this "command".
+		flags.GetOptionUsageGroupServiceTcp(false),
+		flags.GetOptionUsageHostId(false),
+		flags.GetOptionUsageNewId(false))
+}
+
+// GetCmdExampleRenameHost - Generates the command example string for the cobra.Command.Example field.
+func GetCmdExampleRenameHost() string {
+	baseCmd := fmt.Sprintf("cfm rename %s", flags.HOST)
+
+	shorthandFormat := fmt.Sprintf("%s %s %s %s",
+		baseCmd,
+		flags.GetOptionExampleShGroupServiceTcp(),
+		flags.GetOptionExampleShHostId(),
+		flags.GetOptionExampleShNewId())
+
+	longhandFormat := fmt.Sprintf("%s %s %s %s",
+		baseCmd,
+		flags.GetOptionExampleLhGroupServiceTcp(),
+		flags.GetOptionExampleLhHostId(),
+		flags.GetOptionExampleLhNewId())
+
+	return fmt.Sprintf(`
+	%s
+
+	%s`, shorthandFormat, longhandFormat)
 }

--- a/cmd/cfm-cli/cmd/resyncAppliance.go
+++ b/cmd/cfm-cli/cmd/resyncAppliance.go
@@ -5,19 +5,17 @@ package cmd
 import (
 	"cfm/cli/pkg/serviceLib/flags"
 	"cfm/cli/pkg/serviceLib/serviceRequests"
+	"fmt"
 
 	"github.com/spf13/cobra"
 )
 
 var resyncApplianceCmd = &cobra.Command{
-	Use:   `appliance [--serv-ip | -a] [--serv-net-port | -p] <--appliance-id | -L>`,
-	Short: "Resynchronize the cfm service to all the added blades for a specific composable memory appliance (CMA)",
-	Long:  `Resynchronize the cfm service to all the added blades for a specific composable memory appliance (CMA).`,
-	Example: `
-	cfm resync appliance --appliance-id applId --serv-ip 127.0.0.1 --serv-net-port 8080
-
-	cfm resync appliance -L applId -a 127.0.0.1 -p 8080`,
-	Args: cobra.MatchAll(cobra.NoArgs),
+	Use:     GetCmdUsageResyncAppliance(),
+	Short:   "Resynchronize the cfm service to all the added blades for a specific composable memory appliance (CMA)",
+	Long:    `Resynchronize the cfm service to all the added blades for a specific composable memory appliance (CMA).`,
+	Example: GetCmdExampleResyncAppliance(),
+	Args:    cobra.MatchAll(cobra.NoArgs),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		initLogging(cmd)
 		return nil
@@ -39,9 +37,37 @@ func init() {
 
 	initCommonPersistentFlags(resyncApplianceCmd)
 
-	resyncApplianceCmd.Flags().StringP(flags.APPLIANCE_ID, flags.APPLIANCE_ID_SH, flags.ID_DFLT, "ID of composable memory appliance (CMA)")
+	resyncApplianceCmd.Flags().StringP(flags.APPLIANCE_ID, flags.APPLIANCE_ID_SH, flags.ID_DFLT, "ID of composable memory appliance (CMA)\n")
 	resyncApplianceCmd.MarkFlagRequired(flags.APPLIANCE_ID)
 
 	//Add command to parent
 	resyncCmd.AddCommand(resyncApplianceCmd)
+}
+
+// GetCmdUsageResyncAppliance - Generates the command usage string for the cobra.Command.Use field.
+func GetCmdUsageResyncAppliance() string {
+	return fmt.Sprintf("%s %s %s",
+		flags.APPLIANCE, // Note: The first word in the Command.Use string is how Cobra defines the "name" of this "command".
+		flags.GetOptionUsageGroupServiceTcp(false),
+		flags.GetOptionUsageApplianceId(false))
+}
+
+// GetCmdExampleResyncAppliance - Generates the command example string for the cobra.Command.Example field.
+func GetCmdExampleResyncAppliance() string {
+	baseCmd := fmt.Sprintf("cfm resync %s", flags.APPLIANCE)
+
+	shorthandFormat := fmt.Sprintf("%s %s %s",
+		baseCmd,
+		flags.GetOptionExampleShGroupServiceTcp(),
+		flags.GetOptionExampleShApplianceId())
+
+	longhandFormat := fmt.Sprintf("%s %s %s",
+		baseCmd,
+		flags.GetOptionExampleLhGroupServiceTcp(),
+		flags.GetOptionExampleLhApplianceId())
+
+	return fmt.Sprintf(`
+	%s
+
+	%s`, shorthandFormat, longhandFormat)
 }

--- a/cmd/cfm-cli/cmd/resyncBlade.go
+++ b/cmd/cfm-cli/cmd/resyncBlade.go
@@ -5,19 +5,17 @@ package cmd
 import (
 	"cfm/cli/pkg/serviceLib/flags"
 	"cfm/cli/pkg/serviceLib/serviceRequests"
+	"fmt"
 
 	"github.com/spf13/cobra"
 )
 
 var resyncBladeCmd = &cobra.Command{
-	Use:   `blade  [--serv-ip | -a] [--serv-net-port | -p] <--appliance-id | -L> <--blade-id | -B>`,
-	Short: "Resynchronize the cfm service to a single blade on a specific composable memory appliance (CMA)",
-	Long:  `Resynchronize the cfm service to a single blade on a specific composable memory appliance (CMA).`,
-	Example: `
-	cfm resync blade --appliance-id applId --blade-id bladeId --serv-ip 127.0.0.1 --serv-net-port 8080
-
-	cfm resync blade -L applId -B bladeId -a 127.0.0.1 -p 8080`,
-	Args: cobra.MatchAll(cobra.NoArgs),
+	Use:     GetCmdUsageResyncBlade(),
+	Short:   "Resynchronize the cfm service to a single blade on a specific composable memory appliance (CMA)",
+	Long:    `Resynchronize the cfm service to a single blade on a specific composable memory appliance (CMA).`,
+	Example: GetCmdExampleResyncBlade(),
+	Args:    cobra.MatchAll(cobra.NoArgs),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		initLogging(cmd)
 		return nil
@@ -39,11 +37,42 @@ func init() {
 
 	initCommonPersistentFlags(resyncBladeCmd)
 
-	resyncBladeCmd.Flags().StringP(flags.APPLIANCE_ID, flags.APPLIANCE_ID_SH, flags.ID_DFLT, "ID of blade's appliance")
+	resyncBladeCmd.Flags().StringP(flags.APPLIANCE_ID, flags.APPLIANCE_ID_SH, flags.ID_DFLT, "ID of blade's appliance\n")
 	resyncBladeCmd.MarkFlagRequired(flags.APPLIANCE_ID)
-	resyncBladeCmd.Flags().StringP(flags.BLADE_ID, flags.BLADE_ID_SH, flags.ID_DFLT, "ID of blade")
+	resyncBladeCmd.Flags().StringP(flags.BLADE_ID, flags.BLADE_ID_SH, flags.ID_DFLT, "ID of blade\n")
 	resyncBladeCmd.MarkFlagRequired(flags.BLADE_ID)
 
 	//Add command to parent
 	resyncCmd.AddCommand(resyncBladeCmd)
+}
+
+// GetCmdUsageResyncBlade - Generates the command usage string for the cobra.Command.Use field.
+func GetCmdUsageResyncBlade() string {
+	return fmt.Sprintf("%s %s %s %s",
+		flags.BLADE, // Note: The first word in the Command.Use string is how Cobra defines the "name" of this "command".
+		flags.GetOptionUsageGroupServiceTcp(false),
+		flags.GetOptionUsageApplianceId(false),
+		flags.GetOptionUsageBladeId(false))
+}
+
+// GetCmdExampleResyncBlade - Generates the command example string for the cobra.Command.Example field.
+func GetCmdExampleResyncBlade() string {
+	baseCmd := fmt.Sprintf("cfm resync %s", flags.BLADE)
+
+	shorthandFormat := fmt.Sprintf("%s %s %s %s",
+		baseCmd,
+		flags.GetOptionExampleShGroupServiceTcp(),
+		flags.GetOptionExampleShApplianceId(),
+		flags.GetOptionExampleShBladeId())
+
+	longhandFormat := fmt.Sprintf("%s %s %s %s",
+		baseCmd,
+		flags.GetOptionExampleLhGroupServiceTcp(),
+		flags.GetOptionExampleLhApplianceId(),
+		flags.GetOptionExampleLhBladeId())
+
+	return fmt.Sprintf(`
+	%s
+
+	%s`, shorthandFormat, longhandFormat)
 }

--- a/cmd/cfm-cli/cmd/resyncHost.go
+++ b/cmd/cfm-cli/cmd/resyncHost.go
@@ -5,19 +5,17 @@ package cmd
 import (
 	"cfm/cli/pkg/serviceLib/flags"
 	"cfm/cli/pkg/serviceLib/serviceRequests"
+	"fmt"
 
 	"github.com/spf13/cobra"
 )
 
 var resyncHostCmd = &cobra.Command{
-	Use:   `host [--serv-ip | -i] [--serv-net-port | -p] <--host-id | -H>`,
-	Short: `Resynchronize the cfm service to a single cxl host`,
-	Long:  `Resynchronize the cfm service to a single cxl host.`,
-	Example: `
-	cfm resync host --host-id hostId --serv-ip 127.0.0.1 --serv-net-port 8080
-
-	cfm resync host -H hostId -a 127.0.0.1 -p 8080`,
-	Args: cobra.MatchAll(cobra.NoArgs),
+	Use:     GetCmdUsageResyncHost(),
+	Short:   `Resynchronize the cfm service to a single cxl host`,
+	Long:    `Resynchronize the cfm service to a single cxl host.`,
+	Example: GetCmdExampleResyncHost(),
+	Args:    cobra.MatchAll(cobra.NoArgs),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		initLogging(cmd)
 		return nil
@@ -39,9 +37,37 @@ func init() {
 
 	initCommonPersistentFlags(resyncHostCmd)
 
-	resyncHostCmd.Flags().StringP(flags.HOST_ID, flags.HOST_ID_SH, flags.ID_DFLT, "ID of CXL host")
+	resyncHostCmd.Flags().StringP(flags.HOST_ID, flags.HOST_ID_SH, flags.ID_DFLT, "ID of CXL host\n")
 	resyncHostCmd.MarkFlagRequired(flags.HOST_ID)
 
 	//Add command to parent
 	resyncCmd.AddCommand(resyncHostCmd)
+}
+
+// GetCmdUsageResyncHost - Generates the command usage string for the cobra.Command.Use field.
+func GetCmdUsageResyncHost() string {
+	return fmt.Sprintf("%s %s %s",
+		flags.HOST, // Note: The first word in the Command.Use string is how Cobra defines the "name" of this "command".
+		flags.GetOptionUsageGroupServiceTcp(false),
+		flags.GetOptionUsageHostId(false))
+}
+
+// GetCmdExampleResyncHost - Generates the command example string for the cobra.Command.Example field.
+func GetCmdExampleResyncHost() string {
+	baseCmd := fmt.Sprintf("cfm resync %s", flags.HOST)
+
+	shorthandFormat := fmt.Sprintf("%s %s %s",
+		baseCmd,
+		flags.GetOptionExampleShGroupServiceTcp(),
+		flags.GetOptionExampleShHostId())
+
+	longhandFormat := fmt.Sprintf("%s %s %s",
+		baseCmd,
+		flags.GetOptionExampleLhGroupServiceTcp(),
+		flags.GetOptionExampleLhHostId())
+
+	return fmt.Sprintf(`
+	%s
+
+	%s`, shorthandFormat, longhandFormat)
 }

--- a/cmd/cfm-cli/cmd/root.go
+++ b/cmd/cfm-cli/cmd/root.go
@@ -67,12 +67,8 @@ func initLogging(cmd *cobra.Command) {
 // Need to ONLY add them in the subcommand init() func so these flags ONLY show up in the help output when they can actually be used.
 func initCommonPersistentFlags(cmd *cobra.Command) {
 	//Add globally required cfm-service TCPIP connection flags
-	cmd.PersistentFlags().StringP(flags.SERVICE_NET_IP, flags.SERVICE_NET_IP_SH, flags.SERVICE_NET_IP_DFLT, "cfm-service network IP address")
-	cmd.PersistentFlags().Uint16P(flags.SERVICE_NET_PORT, flags.SERVICE_NET_PORT_SH, flags.SERVICE_NET_PORT_DFLT, "cfm-service network port")
-
-	//Currently unused but need default values downstream
-	cmd.PersistentFlags().Bool(flags.SERVICE_INSECURE, flags.SERVICE_INSECURE_DFLT, "cfm-service insecure connection flag")
-	cmd.PersistentFlags().MarkHidden(flags.SERVICE_INSECURE)
-	cmd.PersistentFlags().String(flags.SERVICE_PROTOCOL, flags.SERVICE_PROTOCOL_DFLT, "cfm-service network connection protocol (http/https)")
-	cmd.PersistentFlags().MarkHidden(flags.SERVICE_PROTOCOL)
+	cmd.PersistentFlags().StringP(flags.SERVICE_NET_IP, flags.SERVICE_NET_IP_SH, flags.SERVICE_NET_IP_DFLT, "cfm-service network IP address\n")
+	cmd.PersistentFlags().Uint16P(flags.SERVICE_NET_PORT, flags.SERVICE_NET_PORT_SH, flags.SERVICE_NET_PORT_DFLT, "cfm-service network port\n")
+	cmd.PersistentFlags().BoolP(flags.SERVICE_INSECURE, flags.SERVICE_INSECURE_SH, flags.SERVICE_INSECURE_DFLT, "cfm-service insecure connection flag\n (default false)")
+	cmd.PersistentFlags().StringP(flags.SERVICE_PROTOCOL, flags.SERVICE_PROTOCOL_SH, flags.SERVICE_PROTOCOL_DFLT, "cfm-service network connection protocol (http/https)\n")
 }

--- a/cmd/cfm-cli/cmd/unassignBlade.go
+++ b/cmd/cfm-cli/cmd/unassignBlade.go
@@ -11,14 +11,11 @@ import (
 )
 
 var unassignBladeCmd = &cobra.Command{
-	Use:   "blade  [--serv-ip | -a] [--serv-net-port | -p] <--appliance-id | -L>  <--blade-id | -B> <--memory-id | -m> <--port-id | -o>",
-	Short: "Unassign an existing blade memory region from a blade port.",
-	Long:  `Unassign an existing blade memory region from a blade port.`,
-	Example: `
-	cfm unassign blade --serv-ip 127.0.0.1 --serv-net-port 8080 --appliance-id applId --blade-id bladeId --memory-id memoryId --port-id portId
-
-	cfm unassign blade -a 127.0.0.1 -p 8080 -L applId  -B bladeId -m memoryId -o portId`,
-	Args: cobra.MatchAll(cobra.NoArgs),
+	Use:     GetCmdUsageUnassignBlade(),
+	Short:   "Unassign an existing blade memory region from a blade port.",
+	Long:    `Unassign an existing blade memory region from a blade port.`,
+	Example: GetCmdExampleUnassignBlade(),
+	Args:    cobra.MatchAll(cobra.NoArgs),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		initLogging(cmd)
 		return nil
@@ -44,17 +41,54 @@ var unassignBladeCmd = &cobra.Command{
 func init() {
 	unassignBladeCmd.DisableFlagsInUseLine = true
 
-	unassignBladeCmd.Flags().StringP(flags.APPLIANCE_ID, flags.APPLIANCE_ID_SH, flags.ID_DFLT, "ID of appliance to interrogate")
+	unassignBladeCmd.Flags().StringP(flags.APPLIANCE_ID, flags.APPLIANCE_ID_SH, flags.ID_DFLT, "ID of appliance to interrogate\n")
 	unassignBladeCmd.MarkFlagRequired(flags.APPLIANCE_ID)
-	unassignBladeCmd.Flags().StringP(flags.BLADE_ID, flags.BLADE_ID_SH, flags.ID_DFLT, "ID of appliance blade to interrogate")
+	unassignBladeCmd.Flags().StringP(flags.BLADE_ID, flags.BLADE_ID_SH, flags.ID_DFLT, "ID of appliance blade to interrogate\n")
 	unassignBladeCmd.MarkFlagRequired(flags.BLADE_ID)
-	unassignBladeCmd.Flags().StringP(flags.MEMORY_ID, flags.MEMORY_ID_SH, flags.ID_DFLT, "ID of the appliance blade memory region to unassign from the specified port.")
+	unassignBladeCmd.Flags().StringP(flags.MEMORY_ID, flags.MEMORY_ID_SH, flags.ID_DFLT, "ID of the appliance blade memory region to unassign from the specified port\n")
 	unassignBladeCmd.MarkFlagRequired(flags.MEMORY_ID)
-	unassignBladeCmd.Flags().StringP(flags.PORT_ID, flags.PORT_ID_SH, flags.ID_DFLT, "ID of the appliance blade port to unassign from the specified memory region.")
+	unassignBladeCmd.Flags().StringP(flags.PORT_ID, flags.PORT_ID_SH, flags.ID_DFLT, "ID of the appliance blade port to unassign from the specified memory region\n")
 	unassignBladeCmd.MarkFlagRequired(flags.PORT_ID)
 
 	initCommonPersistentFlags(unassignBladeCmd)
 
 	//Add command to parent
 	unassignCmd.AddCommand(unassignBladeCmd)
+}
+
+// GetCmdUsageUnassignBlade - Generates the command usage string for the cobra.Command.Use field.
+func GetCmdUsageUnassignBlade() string {
+	return fmt.Sprintf("%s %s %s %s %s %s",
+		flags.BLADE, // Note: The first word in the Command.Use string is how Cobra defines the "name" of this "command".
+		flags.GetOptionUsageGroupServiceTcp(false),
+		flags.GetOptionUsageApplianceId(false),
+		flags.GetOptionUsageBladeId(false),
+		flags.GetOptionUsageMemoryId(false),
+		flags.GetOptionUsagePortId(false))
+}
+
+// GetCmdExampleUnassignBlade - Generates the command example string for the cobra.Command.Example field.
+func GetCmdExampleUnassignBlade() string {
+	baseCmd := fmt.Sprintf("cfm unassign %s", flags.BLADE)
+
+	shorthandFormat := fmt.Sprintf("%s %s %s %s %s %s",
+		baseCmd,
+		flags.GetOptionExampleShGroupServiceTcp(),
+		flags.GetOptionExampleShApplianceId(),
+		flags.GetOptionExampleShBladeId(),
+		flags.GetOptionExampleShMemoryId(),
+		flags.GetOptionExampleShPortId())
+
+	longhandFormat := fmt.Sprintf("%s %s %s %s %s %s",
+		baseCmd,
+		flags.GetOptionExampleLhGroupServiceTcp(),
+		flags.GetOptionExampleLhApplianceId(),
+		flags.GetOptionExampleLhBladeId(),
+		flags.GetOptionExampleLhMemoryId(),
+		flags.GetOptionExampleLhPortId())
+
+	return fmt.Sprintf(`
+	%s
+
+	%s`, shorthandFormat, longhandFormat)
 }

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -51,6 +51,9 @@ docker exec -it cfm-container ./cfm-cli -h
 docker exec -it cfm-container ./cfm-cli list appliances
 ```
 
+NOTE: Currently, every cfm-cli command requires various tcpip options (e.g.: --service-net-ip) regarding the specific cfm-service that is being interacted with.
+However, using the docker container, the user can rely on the default cli settings for these cfm-service options since they point to the cfm-service running within the same docker container.
+
 ## Customization
 
 The developer could use the [DockerFile](../docker/Dockerfile) as a reference to build a new docker image using a local [cfm](https://github.com/Seagate/cfm) clone...


### PR DESCRIPTION
All the command "Use" and "Example" strings are hardcoded for each cli command (~30 now) and must EACH be manually updated whenever there is a common change.

Refactor the code to create the strings via a predefined family of functions that allow consistent creation of the usage and example strings for each available cli option.  This makes the code easier to update and eliminates the string inconsistencies (usage and example) across different commands for the same option.