### PR TITLE
feat(webui): device discovery in cfm webui

### DIFF
--- a/webui/src/components/Appliance/Appliances.vue
+++ b/webui/src/components/Appliance/Appliances.vue
@@ -93,6 +93,7 @@
                 variant="text"
                 id="addBlade"
                 @click="addNewBladeWindowButton"
+                :disabled="isAddBladeButtonDisabled"
               >
                 <v-icon start color="#6ebe4a">mdi-plus-thick</v-icon>
                 BLADE
@@ -1524,6 +1525,12 @@ export default {
     ComposeMemoryButton,
   },
 
+  computed: {
+    isAddBladeButtonDisabled() {
+      return this.selectedApplianceId === "CMA_Discovered_Blades";
+    },
+  },
+
   methods: {
     /* Open the add appliance popup */
     addNewApplianceWindowButton() {
@@ -1985,7 +1992,10 @@ export default {
               applianceStore.selectedApplianceId,
               newBladeId
             ),
-            bladeStore.fetchBladeById(applianceStore.selectedApplianceId, newBladeId),
+            bladeStore.fetchBladeById(
+              applianceStore.selectedApplianceId,
+              newBladeId
+            ),
           ]);
           // Update the URL with the new blade ID
           updateUrlWithBladeId(applianceStore.selectedApplianceId, newBladeId);

--- a/webui/src/components/Dashboard/Dashboard.vue
+++ b/webui/src/components/Dashboard/Dashboard.vue
@@ -3,7 +3,7 @@
   <v-container
     style="
       width: 100%;
-      height: 80vh;
+      height: 100vh;
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -47,22 +47,93 @@
         {{ "mdi-close" }}
       </v-icon>
     </div>
-
-    <VueFlow
-      :nodes="nodes"
-      :edges="edges"
-      class="basic-flow"
-      :default-viewport="{ zoom: 1 }"
-      :min-zoom="0.2"
-      :max-zoom="4"
-      @node-click="handleNodeClick"
-    >
-      <Controls position="top-left">
-        <ControlButton title="Search" @click="toggleSearch">
-          <v-icon>mdi-magnify</v-icon>
-        </ControlButton>
-      </Controls>
-    </VueFlow>
+        <v-card class="parent-card"
+          style="
+            width: 100%;
+            height: 100%;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+          "
+        >
+          <div
+            style="
+              width: 100%;
+              height: 100%;
+              position: relative;
+              overflow: hidden;
+            "
+          >
+            <VueFlow
+              :nodes="nodes"
+              :edges="edges"
+              class="basic-flow"
+              :default-viewport="{ zoom: 1 }"
+              :min-zoom="0.2"
+              :max-zoom="4"
+              @node-click="handleNodeClick"
+              style="width: 100%; height: 100%;"
+            >
+              <Controls position="top-left">
+                <ControlButton title="Search" @click="toggleSearch">
+                  <v-icon>mdi-magnify</v-icon>
+                </ControlButton>
+              </Controls>
+            </VueFlow>
+          </div>
+          <v-card class="child-card"
+          style="
+            width: 20%;
+            height: 50%;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+          "
+        >
+          <v-card-text>
+            Devices
+            <v-list-item>
+              <v-list-item-title>
+                <v-icon color="#f2ae72" class="mr-2">mdi-rectangle</v-icon>
+                CMA
+              </v-list-item-title>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-title>
+                <v-icon color="#f2e394" class="mr-2">mdi-rectangle</v-icon>
+                Blade
+              </v-list-item-title>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-title>
+                <v-icon color="#d9ecd0" class="mr-2">mdi-rectangle</v-icon>
+                Host
+              </v-list-item-title>
+            </v-list-item>
+            <br>Status
+            <v-list-item>
+              <v-list-item-title>
+                <v-icon color="#6ebe4a" class="mr-2">mdi-rectangle-outline</v-icon>
+                online
+              </v-list-item-title>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-title>
+                <v-icon color="#b00020" class="mr-2">mdi-rectangle-outline</v-icon>
+                offline
+              </v-list-item-title>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-title>
+                <v-icon color="#ff9f40" class="mr-2">mdi-rectangle-outline</v-icon>
+                unavailable
+              </v-list-item-title>
+            </v-list-item>
+          </v-card-text>
+        </v-card>
+        </v-card>
 
     <!-- The dialog of the warning before the adding the new discovered devices(blades or cxl-hosts) -->
     <v-dialog v-model="dialogNewDiscoveredDevices" max-width="600px">
@@ -208,7 +279,7 @@ export default {
     return {
       addNewDiscoveredDevicesProgressText:
         "Adding the selected devices, please wait...",
-      discoverDevicesProgressText:"Discovering the selected devices, please wait...",
+      discoverDevicesProgressText:"Discovering devices, please wait...",
 
       dialogNewDiscoveredDevices: false,
       dialogAddNewDiscoveredDevicesWait: false,
@@ -445,5 +516,17 @@ export default {
 .scrollable-content {
   max-height: 300px;
   overflow-y: auto;
+}
+
+.parent-card {
+  position: relative;
+}
+
+.child-card {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background-color: #f5f5f5;
+  border: 1px solid #ccc;
 }
 </style>

--- a/webui/src/components/Dashboard/Dashboard.vue
+++ b/webui/src/components/Dashboard/Dashboard.vue
@@ -128,6 +128,20 @@
       </v-row>
     </v-dialog>
 
+    <v-dialog v-model="dialogDiscoverDevicesWait">
+      <v-row align-content="center" class="fill-height" justify="center">
+        <v-col cols="6">
+          <v-progress-linear color="#6ebe4a" height="50" indeterminate rounded>
+            <template v-slot:default>
+              <div class="text-center">
+                {{ discoverDevicesProgressText }}
+              </div>
+            </template>
+          </v-progress-linear>
+        </v-col>
+      </v-row>
+    </v-dialog>
+
     <v-dialog v-model="dialogAddNewDiscoveredDevicesOutput" max-width="600px">
       <v-sheet
         elevation="12"
@@ -194,10 +208,12 @@ export default {
     return {
       addNewDiscoveredDevicesProgressText:
         "Adding the selected devices, please wait...",
+      discoverDevicesProgressText:"Discovering the selected devices, please wait...",
 
       dialogNewDiscoveredDevices: false,
       dialogAddNewDiscoveredDevicesWait: false,
       dialogAddNewDiscoveredDevicesOutput: false,
+      dialogDiscoverDevicesWait: false,
 
       discoveredBlades: [],
       discoveredHosts: [],
@@ -212,6 +228,7 @@ export default {
 
   methods: {
     async discoverDevices() {
+      this.dialogDiscoverDevicesWait = true;
       const applianceStore = useApplianceStore();
       const hostStore = useHostStore();
 
@@ -224,8 +241,11 @@ export default {
         this.discoveredHosts = responseOfHosts || [];
 
         this.dialogNewDiscoveredDevices = true;
+        this.dialogDiscoverDevicesWait = false;
+
         return response.length ? response : [];
       } catch (error) {
+        this.dialogDiscoverDevicesWait = false;
         console.error("Error fetching data:", error);
         return [];
       }

--- a/webui/src/components/Dashboard/Dashboard.vue
+++ b/webui/src/components/Dashboard/Dashboard.vue
@@ -57,14 +57,6 @@
             justify-content: center;
           "
         >
-          <div
-            style="
-              width: 100%;
-              height: 100%;
-              position: relative;
-              overflow: hidden;
-            "
-          >
             <VueFlow
               :nodes="nodes"
               :edges="edges"
@@ -73,7 +65,6 @@
               :min-zoom="0.2"
               :max-zoom="4"
               @node-click="handleNodeClick"
-              style="width: 100%; height: 100%;"
             >
               <Controls position="top-left">
                 <ControlButton title="Search" @click="toggleSearch">
@@ -81,7 +72,6 @@
                 </ControlButton>
               </Controls>
             </VueFlow>
-          </div>
           <v-card class="child-card"
           style="
             width: 20%;
@@ -170,14 +160,14 @@
           <v-btn
             color="info"
             variant="text"
-            id="cancelResyncBlade"
+            id="cancelAddSelecteddDevices"
             @click="dialogNewDiscoveredDevices = false"
             >Cancel</v-btn
           >
           <v-btn
             color="info"
             variant="text"
-            id="confirmResyncBlade"
+            id="confirmAddSelecteddDevices"
             @click="addDiscoveredDevices"
             >Add</v-btn
           >
@@ -249,7 +239,7 @@
             rounded
             variant="flat"
             width="90"
-            id="addNewApplianceSuccess"
+            id="addNewDiscoveredDevicesOutput"
             @click="dialogAddNewDiscoveredDevicesOutput = false"
           >
             Done

--- a/webui/src/components/Dashboard/Dashboard.vue
+++ b/webui/src/components/Dashboard/Dashboard.vue
@@ -83,6 +83,7 @@
             v-model="selectedBlades"
             :value="blade"
           ></v-checkbox>
+          <br>
           New Discovered Hosts:
           <v-checkbox
             v-for="(host, index) in discoveredHosts"
@@ -412,7 +413,7 @@ export default {
 
 <style scoped>
 .scrollable-content {
-  max-height: 300px; /* Adjust height as needed */
+  max-height: 300px;
   overflow-y: auto;
 }
 </style>

--- a/webui/src/components/Dashboard/Dashboard.vue
+++ b/webui/src/components/Dashboard/Dashboard.vue
@@ -257,6 +257,7 @@ export default {
 
       const applianceStore = useApplianceStore();
       const hostStore = useHostStore();
+      const bladePortStore = useBladePortStore();
 
       if (this.selectedBlades.length === 0) {
         console.log("No blades selected.");
@@ -290,6 +291,15 @@ export default {
           } catch (error) {
             console.error("Error adding new discovered host:", error);
           }
+        }
+      }
+
+      // Update the graph content
+      await applianceStore.fetchAppliances();
+      await hostStore.fetchHosts();
+      for (const appliance of applianceStore.applianceIds) {
+        for (const blade of appliance.blades) {
+          await bladePortStore.fetchBladePorts(appliance.id, blade.id);
         }
       }
 

--- a/webui/src/components/Dashboard/initial-control-elements.ts
+++ b/webui/src/components/Dashboard/initial-control-elements.ts
@@ -38,9 +38,9 @@ export const useControlData = () => {
           style: { backgroundColor: "#f2ae72", color: "#000" },
           type: applianceNodeType,
         },
-        ...appliance.bladeIds.map((bladeId, bladeIndex) => ({
-          id: `blade-${bladeId}`,
-          data: { label: bladeId, url: `/appliances/${appliance.id}/blades/${bladeId}`, associatedAppliance: appliance.id },
+        ...appliance.blades.map((blade, bladeIndex) => ({
+          id: `blade-${blade.id}`,
+          data: { label: blade.id, url: `/appliances/${appliance.id}/blades/${blade.id}`, associatedAppliance: appliance.id },
           position: position,
           style: { backgroundColor: "#f2e394", color: "#000" },
           type: bladeNodeType,
@@ -49,8 +49,8 @@ export const useControlData = () => {
     );
 
     const hostNodes = hostStore.hostIds.map((host, index) => ({
-      id: `host-${host}`,
-      data: { label: host, url: `/hosts/${host}` },
+      id: `host-${host.id}`,
+      data: { label: host.id, url: `/hosts/${host.id}` },
       position: position,
       style: { backgroundColor: "#d9ecd0", color: "#000" },
       type: hostNodeType,
@@ -67,18 +67,18 @@ export const useControlData = () => {
             source: "cfm-service",
             target: `appliance-${appliance.id}`,
           },
-          ...appliance.bladeIds.map((bladeId) => ({
-            id: `appliance-blade-${appliance.id}-${bladeId}`,
+          ...appliance.blades.map((blade) => ({
+            id: `appliance-blade-${appliance.id}-${blade.id}`,
             source: `appliance-${appliance.id}`,
-            target: `blade-${bladeId}`,
+            target: `blade-${blade.id}`,
           })),
         ])
         : [];
 
       const hostEdges = hostStore.hostIds.map((host) => ({
-        id: `cfm-${host}`,
+        id: `cfm-${host.id}`,
         source: "cfm-service",
-        target: `host-${host}`,
+        target: `host-${host.id}`,
       }));
 
       return [...coreEdges, ...hostEdges];
@@ -97,19 +97,19 @@ export const useControlData = () => {
           target: `appliance-${appliance.id}`,
           animated: true,
         },
-        ...appliance.bladeIds.map((bladeId) => ({
-          id: `appliance-blade-${appliance.id}-${bladeId}`,
+        ...appliance.blades.map((blade) => ({
+          id: `appliance-blade-${appliance.id}-${blade.id}`,
           source: `appliance-${appliance.id}`,
-          target: `blade-${bladeId}`,
+          target: `blade-${blade.id}`,
           animated: true,
         })),
       ])
       : [];
 
     const hostEdges = hostStore.hostIds.map((host) => ({
-      id: `cfm-${host}`,
+      id: `cfm-${host.id}`,
       source: "cfm-service",
-      target: `host-${host}`,
+      target: `host-${host.id}`,
       animated: true,
     }));
 

--- a/webui/src/components/Dashboard/initial-control-elements.ts
+++ b/webui/src/components/Dashboard/initial-control-elements.ts
@@ -23,7 +23,7 @@ export const useControlData = () => {
           id: "cfm-service",
           data: { label: "CFM Service", },
           position: position,
-          style: { backgroundColor: "#6ebe4a", color: "#000" },
+          style: { backgroundColor: useLayout().Colors.serviceColor, border: "none" },
           type: serviceNodeType,
         },
       ]
@@ -35,26 +35,33 @@ export const useControlData = () => {
           id: `appliance-${appliance.id}`,
           data: { label: appliance.id, url: `/appliances/${appliance.id}` },
           position: position,
-          style: { backgroundColor: "#f2ae72", color: "#000" },
+          style: { backgroundColor: useLayout().Colors.applianceColor, border: "none" },
           type: applianceNodeType,
         },
-        ...appliance.blades.map((blade, bladeIndex) => ({
-          id: `blade-${blade.id}`,
-          data: { label: blade.id, url: `/appliances/${appliance.id}/blades/${blade.id}`, associatedAppliance: appliance.id },
-          position: position,
-          style: { backgroundColor: "#f2e394", color: "#000" },
-          type: bladeNodeType,
-        })),
+        ...appliance.blades.map((blade, bladeIndex) => {
+          const borderColor = useLayout().borderColorChange(blade.status);
+          return {
+            id: `blade-${blade.id}`,
+            data: { label: blade.id, url: `/appliances/${appliance.id}/blades/${blade.id}`, associatedAppliance: appliance.id },
+            position: position,
+            style: { backgroundColor: useLayout().Colors.baldeColor, border: `3px solid ${borderColor}` },
+            type: bladeNodeType,
+          }
+        }),
       ]
     );
 
-    const hostNodes = hostStore.hostIds.map((host, index) => ({
-      id: `host-${host.id}`,
-      data: { label: host.id, url: `/hosts/${host.id}` },
-      position: position,
-      style: { backgroundColor: "#d9ecd0", color: "#000" },
-      type: hostNodeType,
-    }));
+    const hostNodes = hostStore.hostIds.map((host, index) => {
+      const borderColor = useLayout().borderColorChange(host.status);
+
+      return {
+        id: `host-${host.id}`,
+        data: { label: host.id, url: `/hosts/${host.id}` },
+        position: position,
+        style: { backgroundColor: useLayout().Colors.hostColor, border: `3px solid ${borderColor}` },
+        type: hostNodeType,
+      }
+    });
 
     const allNodes = [...coreNode, ...applianceNodes, ...hostNodes];
 

--- a/webui/src/components/Dashboard/initial-data-elements.ts
+++ b/webui/src/components/Dashboard/initial-data-elements.ts
@@ -18,7 +18,7 @@ export const useData = () => {
         let currentYPosition = 0;
         const applianceNodes = applianceStore.applianceIds.flatMap(
             (appliance, index) => {
-                const bladeCount = appliance.bladeIds.length;
+                const bladeCount = appliance.blades.length;
                 const applianceHeight = 50 + bladeCount * 50; // Adjust height based on number of blades
                 const applianceWidth = 270; // Width of the appliance node
                 const bladeWidth = 250; // Width of the blade node
@@ -34,9 +34,9 @@ export const useData = () => {
                     targetPosition: 'left',
                 };
 
-                const bladeNodes = appliance.bladeIds.map((bladeId, bladeIndex) => ({
-                    id: `blade-${bladeId}`,
-                    data: { label: bladeId, url: `/appliances/${appliance.id}/blades/${bladeId}`, associatedAppliance: appliance.id },
+                const bladeNodes = appliance.blades.map((blade, bladeIndex) => ({
+                    id: `blade-${blade.id}`,
+                    data: { label: blade.id, url: `/appliances/${appliance.id}/blades/${blade.id}`, associatedAppliance: appliance.id },
                     position: { x: bladeXPosition, y: 50 + bladeIndex * 50 }, // Center blades within the appliance node
                     style: { backgroundColor: "#f2e394", color: "#000", width: `${bladeWidth}px` },
                     type: bladeNodeType,
@@ -54,11 +54,11 @@ export const useData = () => {
         );
 
         const hostNodes = hostStore.hostIds.map((host, index) => {
-            const { width, height } = useLayout().measureText(host);
+            const { width, height } = useLayout().measureText(host.id);
 
             return {
-                id: `host-${host}`,
-                data: { label: host, url: `/hosts/${host}` },
+                id: `host-${host.id}`,
+                data: { label: host.id, url: `/hosts/${host.id}` },
                 position: { x: 500, y: index * 200 },
                 style: {
                     backgroundColor: "#d9ecd0",

--- a/webui/src/components/Dashboard/initial-data-elements.ts
+++ b/webui/src/components/Dashboard/initial-data-elements.ts
@@ -3,6 +3,7 @@ import { computed } from "vue";
 import { useApplianceStore } from "../Stores/ApplianceStore";
 import { useHostStore } from "../Stores/HostStore";
 import { useBladePortStore } from "../Stores/BladePortStore";
+import { useLayout } from "./useLayout";
 
 export const useData = () => {
     const applianceStore = useApplianceStore();
@@ -52,15 +53,24 @@ export const useData = () => {
             }
         );
 
-        const hostNodes = hostStore.hostIds.map((host, index) => ({
-            id: `host-${host}`,
-            data: { label: host, url: `/hosts/${host}` },
-            position: { x: 500, y: index * 200 },
-            style: { backgroundColor: "#d9ecd0", color: "#000" },
-            type: hostNodeType,
-            sourcePosition: 'right',
-            targetPosition: 'left',
-        }));
+        const hostNodes = hostStore.hostIds.map((host, index) => {
+            const { width, height } = useLayout().measureText(host);
+
+            return {
+                id: `host-${host}`,
+                data: { label: host, url: `/hosts/${host}` },
+                position: { x: 500, y: index * 200 },
+                style: {
+                    backgroundColor: "#d9ecd0",
+                    color: "#000",
+                    width: `${width + 20}px`, // Adding some padding
+                    height: `${height + 20}px` // Adding some padding
+                },
+                type: hostNodeType,
+                sourcePosition: 'right',
+                targetPosition: 'left',
+            };
+        });
 
         return [...applianceNodes, ...hostNodes];
     });

--- a/webui/src/components/Dashboard/initial-data-elements.ts
+++ b/webui/src/components/Dashboard/initial-data-elements.ts
@@ -28,24 +28,27 @@ export const useData = () => {
                     id: `appliance-${appliance.id}`,
                     data: { label: appliance.id, url: `/appliances/${appliance.id}` },
                     position: { x: 100, y: currentYPosition },
-                    style: { backgroundColor: "rgba(242, 174, 114, 0.5)", color: "#000", height: `${applianceHeight}px`, width: `${applianceWidth}px` },
+                    style: { backgroundColor: useLayout().Colors.applianceColor, height: `${applianceHeight}px`, width: `${applianceWidth}px`, border: "none" },
                     type: applianceNodeType,
                     sourcePosition: 'right',
                     targetPosition: 'left',
                 };
 
-                const bladeNodes = appliance.blades.map((blade, bladeIndex) => ({
-                    id: `blade-${blade.id}`,
-                    data: { label: blade.id, url: `/appliances/${appliance.id}/blades/${blade.id}`, associatedAppliance: appliance.id },
-                    position: { x: bladeXPosition, y: 50 + bladeIndex * 50 }, // Center blades within the appliance node
-                    style: { backgroundColor: "#f2e394", color: "#000", width: `${bladeWidth}px` },
-                    type: bladeNodeType,
-                    parentNode: `appliance-${appliance.id}`,
-                    extent: 'parent',
-                    expandParent: true,
-                    sourcePosition: 'right',
-                    targetPosition: 'left',
-                }));
+                const bladeNodes = appliance.blades.map((blade, bladeIndex) => {
+                    const borderColor = useLayout().borderColorChange(blade.status);
+                    return {
+                        id: `blade-${blade.id}`,
+                        data: { label: blade.id, url: `/appliances/${appliance.id}/blades/${blade.id}`, associatedAppliance: appliance.id },
+                        position: { x: bladeXPosition, y: 50 + bladeIndex * 50 }, // Center blades within the appliance node
+                        style: { backgroundColor: useLayout().Colors.baldeColor, width: `${bladeWidth}px`, border: `3px solid ${borderColor}` },
+                        type: bladeNodeType,
+                        parentNode: `appliance-${appliance.id}`,
+                        extent: 'parent',
+                        expandParent: true,
+                        sourcePosition: 'right',
+                        targetPosition: 'left',
+                    }
+                });
 
                 currentYPosition += applianceHeight + 20; // Add some space between nodes
 
@@ -55,16 +58,18 @@ export const useData = () => {
 
         const hostNodes = hostStore.hostIds.map((host, index) => {
             const { width, height } = useLayout().measureText(host.id);
+            const borderColor = useLayout().borderColorChange(host.status);
 
             return {
                 id: `host-${host.id}`,
                 data: { label: host.id, url: `/hosts/${host.id}` },
                 position: { x: 500, y: index * 200 },
                 style: {
-                    backgroundColor: "#d9ecd0",
+                    backgroundColor: useLayout().Colors.hostColor,
                     color: "#000",
                     width: `${width + 20}px`, // Adding some padding
-                    height: `${height + 20}px` // Adding some padding
+                    height: `${height + 20}px`, // Adding some padding
+                    border: `3px solid ${borderColor}`
                 },
                 type: hostNodeType,
                 sourcePosition: 'right',

--- a/webui/src/components/Dashboard/useLayout.ts
+++ b/webui/src/components/Dashboard/useLayout.ts
@@ -20,6 +20,26 @@ export function measureText(text: string, font = '16px Arial') {
   };
 };
 
+export const Colors = {
+  applianceColor: '#f2ae72',
+  baldeColor: '#f2e394',
+  hostColor: '#d9ecd0',
+  serviceColor: '#6ebe4a',
+};
+
+export function borderColorChange(status: string | undefined) {
+  switch (status) {
+    case "online":
+      return "#6ebe4a"; // green
+    case "offline":
+      return "#b00020"; // Red
+    case "unavailable":
+      return "#ff9f40"; // Orange
+    default:
+      return "#ffffff"; // White
+  }
+};
+
 export function useLayout() {
   const { findNode } = useVueFlow();
 
@@ -74,5 +94,5 @@ export function useLayout() {
     });
   }
 
-  return { graph, layout, previousDirection, measureText };
+  return { graph, layout, previousDirection, measureText, borderColorChange, Colors };
 }

--- a/webui/src/components/Stores/ApplianceStore.ts
+++ b/webui/src/components/Stores/ApplianceStore.ts
@@ -14,7 +14,7 @@ export const useApplianceStore = defineStore('appliance', {
         addApplianceError: null as unknown,
         deleteApplianceError: null as unknown,
         renameApplianceError: null as unknown,
-        applianceIds: [] as { id: string, blades: { id: string, ipAddress: string }[] }[],
+        applianceIds: [] as { id: string, blades: { id: string, ipAddress: string, status: string | undefined }[] }[],
         discoveredBlades: [] as DiscoveredDevice[],
 
         prefixBladeId: "Discoverd_Blade_",
@@ -104,7 +104,7 @@ export const useApplianceStore = defineStore('appliance', {
                             // Store blade in blades
                             if (bladeId) {
                                 const responseOfBlade = await defaultApi.bladesGetById(applianceId, bladeId);
-                                const response = { id: responseOfBlade.data.id, ipAddress: responseOfBlade.data.ipAddress }
+                                const response = { id: responseOfBlade.data.id, ipAddress: responseOfBlade.data.ipAddress, status: responseOfBlade.data.status }
                                 associatedBlades.push(response);
                             }
                         }
@@ -172,7 +172,7 @@ export const useApplianceStore = defineStore('appliance', {
             const responseOfBlade = await defaultApi.bladesPost(this.defaultApplianceId, this.newBladeCredentials);
 
             if (responseOfBlade) {
-                const response = { id: responseOfBlade.data.id, ipAddress: responseOfBlade.data.ipAddress };
+                const response = { id: responseOfBlade.data.id, ipAddress: responseOfBlade.data.ipAddress, status: responseOfBlade.data.status };
                 appliance!.blades.push(response);
             }
 

--- a/webui/src/components/Stores/ApplianceStore.ts
+++ b/webui/src/components/Stores/ApplianceStore.ts
@@ -154,11 +154,13 @@ export const useApplianceStore = defineStore('appliance', {
             if (!responseOfApplianceExist) {
                 this.newApplianceCredentials.customId = this.defaultApplianceId;
                 const responseOfAppliance = await defaultApi.appliancesPost(this.newApplianceCredentials);
-                
+
                 // Add the new appliance to the appliances and applianceIds array
-                this.appliances.push(responseOfAppliance.data);
-                const newAppliance = { id: responseOfAppliance.data.id, blades: [] }
-                this.applianceIds.push(newAppliance)
+                if (responseOfAppliance) {
+                    this.appliances.push(responseOfAppliance.data);
+                    const newAppliance = { id: responseOfAppliance.data.id, blades: [] }
+                    this.applianceIds.push(newAppliance)
+                }
             }
 
             // Add the new discovered blade to the default appliance
@@ -173,6 +175,8 @@ export const useApplianceStore = defineStore('appliance', {
                 const response = { id: responseOfBlade.data.id, ipAddress: responseOfBlade.data.ipAddress };
                 appliance!.blades.push(response);
             }
+
+            return responseOfBlade.data;
         },
 
         async addNewAppliance(newAppliance: Credentials) {

--- a/webui/src/components/Stores/HostStore.ts
+++ b/webui/src/components/Stores/HostStore.ts
@@ -19,7 +19,7 @@ export const useHostStore = defineStore('host', {
         deleteHostError: null as unknown,
         resyncHostError: null as unknown,
         renameHostError: null as unknown,
-        hostIds: [] as { id: string, ipAddress: string }[],
+        hostIds: [] as { id: string, ipAddress: string, status: string | undefined }[],
         discoveredHosts: [] as DiscoveredDevice[],
 
         prefixHostId: "Discoverd_Host_",
@@ -56,7 +56,7 @@ export const useHostStore = defineStore('host', {
                     // Store host in hosts
                     if (detailsResponseOfHost) {
                         this.hosts.push(detailsResponseOfHost.data);
-                        const host = { id: detailsResponseOfHost.data.id, ipAddress: detailsResponseOfHost.data.ipAddress }
+                        const host = { id: detailsResponseOfHost.data.id, ipAddress: detailsResponseOfHost.data.ipAddress, status: detailsResponseOfHost.data.status }
                         this.hostIds.push(host)
                     }
                 }
@@ -119,7 +119,7 @@ export const useHostStore = defineStore('host', {
 
             // Update the applianceIds and appliances
             if (responseOfHost) {
-                const response = { id: responseOfHost.data.id, ipAddress: responseOfHost.data.ipAddress }
+                const response = { id: responseOfHost.data.id, ipAddress: responseOfHost.data.ipAddress, status: responseOfHost.data.status }
                 this.hosts.push(responseOfHost.data);
                 this.hostIds.push(response)
             }

--- a/webui/src/components/Stores/HostStore.ts
+++ b/webui/src/components/Stores/HostStore.ts
@@ -109,26 +109,21 @@ export const useHostStore = defineStore('host', {
             }
         },
 
-        async addDiscoveredHosts() {
+        async addDiscoveredHosts(host: DiscoveredDevice) {
             const defaultApi = new DefaultApi(undefined, API_BASE_PATH);
-            for (var g = 0; g < this.discoveredHosts.length; g++) {
-                try {
-                    // Add all the new didcovered hosts
-                    this.newHostCredentials.customId = this.prefixHostId + this.discoveredHosts[g].address;
-                    this.newHostCredentials.ipAddress = this.discoveredHosts[g].address + "";
-                    
-                    const responseOfHost = await defaultApi.hostsPost(this.newHostCredentials);
+            // Add all the new didcovered hosts
+            this.newHostCredentials.customId = this.prefixHostId + host.address;
+            this.newHostCredentials.ipAddress = host.address + "";
 
-                    // Update the applianceIds and appliances
-                    if (responseOfHost) {
-                        const response = { id: responseOfHost.data.id, ipAddress: responseOfHost.data.ipAddress }
-                        this.hosts.push(responseOfHost.data);
-                        this.hostIds.push(response)
-                    }
-                } catch (error) {
-                    console.error(`Error processing host ${g + 1}:`, error);
-                }
+            const responseOfHost = await defaultApi.hostsPost(this.newHostCredentials);
+
+            // Update the applianceIds and appliances
+            if (responseOfHost) {
+                const response = { id: responseOfHost.data.id, ipAddress: responseOfHost.data.ipAddress }
+                this.hosts.push(responseOfHost.data);
+                this.hostIds.push(response)
             }
+            return responseOfHost.data;
         },
 
         async addNewHost(newHost: Credentials) {


### PR DESCRIPTION
All discovered devices are added when cfm is initialized, but the user can discover new available devices without restarting the whole cfm by using the `Click to discover new devices` button on the dashboard page.
<img width="581" alt="1111" src="https://github.com/user-attachments/assets/add48fe8-ec04-4f3c-83f3-3728c30b68a0">
<img width="552" alt="2222" src="https://github.com/user-attachments/assets/d5da324d-ecad-4ac4-b0db-934c6b1489d2">
We prevent the user from manually adding blades to the CMA_Discovered_Blades appliance.
<img width="469" alt="6661" src="https://github.com/user-attachments/assets/e21d32c3-fd0a-4360-8773-e7ff361ded6a">

