### PR TITLE
fix(service): fix device discovery error handling during service starup

### DIFF
--- a/cmd/cfm-service/main.go
+++ b/cmd/cfm-service/main.go
@@ -69,10 +69,12 @@ func main() {
 	api.AddRedfishRouter(ctx, router, defaultRedfishController)
 
 	// Discover devices before loading datastore
-	bladeDevices, _ := services.DiscoverDevices(ctx, defaultApiService, "blade")
-	hostDevices, _ := services.DiscoverDevices(ctx, defaultApiService, "cxl-host")
+	bladeDevices, errBlade := services.DiscoverDevices(ctx, defaultApiService, "blade")
+	hostDevices, errHost := services.DiscoverDevices(ctx, defaultApiService, "cxl-host")
 	// Add the discovered devices into datastore
-	services.AddDiscoveredDevices(ctx, defaultApiService, bladeDevices, hostDevices)
+	if errBlade == nil && errHost == nil {
+		services.AddDiscoveredDevices(ctx, defaultApiService, bladeDevices, hostDevices)
+	}
 
 	// Load datastore
 	datastore.DStore().Restore()

--- a/pkg/api/api_default_service.go
+++ b/pkg/api/api_default_service.go
@@ -1498,7 +1498,7 @@ func (cfm *CfmApiService) RootGet(ctx context.Context) (openapi.ImplResponse, er
 func (cfm *CfmApiService) DiscoverDevices(ctx context.Context, deviceType string) (openapi.ImplResponse, error) {
 	if deviceType != "blade" && deviceType != "cxl-host" {
 		err := common.RequestError{
-			StatusCode: http.StatusBadRequest,
+			StatusCode: common.StatusDeviceDiscoveryFailure,
 			Err:        fmt.Errorf("invalid type parameter"),
 		}
 		return formatErrorResp(ctx, &err)
@@ -1513,7 +1513,7 @@ func (cfm *CfmApiService) DiscoverDevices(ctx context.Context, deviceType string
 	conn, err := dbus.SystemBus()
 	if err != nil {
 		return formatErrorResp(ctx, &common.RequestError{
-			StatusCode: http.StatusInternalServerError,
+			StatusCode: common.StatusDeviceDiscoveryFailure,
 			Err:        fmt.Errorf("cannot get system bus: %v", err),
 		})
 	}
@@ -1521,7 +1521,7 @@ func (cfm *CfmApiService) DiscoverDevices(ctx context.Context, deviceType string
 	server, err := avahi.ServerNew(conn)
 	if err != nil {
 		return formatErrorResp(ctx, &common.RequestError{
-			StatusCode: http.StatusInternalServerError,
+			StatusCode: common.StatusDeviceDiscoveryFailure,
 			Err:        fmt.Errorf("avahi new failed: %v", err),
 		})
 	}
@@ -1530,7 +1530,7 @@ func (cfm *CfmApiService) DiscoverDevices(ctx context.Context, deviceType string
 	sb, err := server.ServiceBrowserNew(avahi.InterfaceUnspec, avahi.ProtoInet, "_obmc_redfish._tcp", "local", 0)
 	if err != nil {
 		return formatErrorResp(ctx, &common.RequestError{
-			StatusCode: http.StatusInternalServerError,
+			StatusCode: common.StatusDeviceDiscoveryFailure,
 			Err:        fmt.Errorf("service browser new failed: %v", err),
 		})
 	}

--- a/pkg/common/status.go
+++ b/pkg/common/status.go
@@ -76,6 +76,7 @@ const (
 	StatusBladeDeleteSessionFailure     //500
 	StatusHostCreateSessionFailure      //500
 	StatusHostDeleteSessionFailure      //500
+	StatusDeviceDiscoveryFailure        //500
 
 	StatusApplianceIdDoesNotExist    //404
 	StatusBladeIdDoesNotExist        //404
@@ -186,6 +187,8 @@ func (e StatusCodeType) String() string {
 		return "Rename Blade Failure"
 	case StatusHostRenameFailure:
 		return "Rename Host Failure"
+	case StatusDeviceDiscoveryFailure:
+		return "Device Discovery Failure"
 	}
 	return "Unknown"
 
@@ -242,7 +245,8 @@ func (e StatusCodeType) HttpStatusCode() int {
 		StatusHostDeleteSessionFailure,
 		StatusApplianceCreateSessionFailure,
 		StatusApplianceDeleteSessionFailure,
-		StatusManagerInitializationFailure:
+		StatusManagerInitializationFailure,
+		StatusDeviceDiscoveryFailure:
 		return http.StatusInternalServerError // 500
 	case StatusAppliancesExceedMaximum,
 		StatusBladesExceedMaximum,

--- a/services/discovery.go
+++ b/services/discovery.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"fmt"
 	"log"
 
 	"golang.org/x/net/context"
@@ -12,12 +13,13 @@ import (
 
 // discoverDevices function to call the DiscoverDevices API
 func DiscoverDevices(ctx context.Context, apiService openapi.DefaultAPIServicer, deviceType string) (openapi.ImplResponse, error) {
-	resp, err := apiService.DiscoverDevices(ctx, deviceType)
-	if err != nil {
-		log.Printf("Error discovering devices of type %s: %v", deviceType, err)
+	resp, _ := apiService.DiscoverDevices(ctx, deviceType)
+	if resp.Code >= 300 {
+		err := fmt.Errorf("error discovering devices of type %s: %+v", deviceType, resp)
+		log.Print(err)
 		return resp, err
 	} else {
-		log.Printf("Discovered devices of type %s: %v", deviceType, resp)
+		log.Printf("Discovered devices of type %s: %+v", deviceType, resp)
 		return resp, nil
 	}
 }


### PR DESCRIPTION
When running cfm-service within the std docker container environment, found an error handling problem during device discovery.

CFM docker container goes into infinite restart loop of what's below

```
I1203 20:21:04.436099       1 main.go:53] "[] cfm-service" version="1.x.x" build="2024-12-03T20:20:01"
I1203 20:21:04.436178       1 main.go:55] "cfm-service" args="-webui -verbosity 4"
I1203 20:21:04.436232       1 main.go:56] "cfm-service" settings={"Version":false,"Verbosity":"4","Backend":"httpfish","Port":"8080","Webui":true,"WebuiPort":"3000","HostIpOverride":""}
2024/12/03 20:21:04 Discovered devices of type blade: {0 {<nil> status [500][Unknown] cannot get system bus: dial unix /var/run/dbus/system_bus_socket: connect: no such file or directory {500 Unknown}}}
2024/12/03 20:21:04 Discovered devices of type cxl-host: {0 {<nil> status [500][Unknown] cannot get system bus: dial unix /var/run/dbus/system_bus_socket: connect: no such file or directory {500 Unknown}}}
I1203 20:21:04.440394       1 singleton.go:104] "restore data store" filename="cfmdatastore.json"
I1203 20:21:04.440625       1 singleton.go:79] "store data store data" filename="cfmdatastore.json"
I1203 20:21:04.440974       1 singleton.go:79] "store data store data" filename="cfmdatastore.json"
2024/12/03 20:21:04 Response body is not []byte
```
The docker container is not allowing access to the system bus (which is one error).
Another error, that this PR fixes, is that the error is not getting handled correctly, as the log messages show above (with the code thinking it has discovered devices when it really has an error).

This fix correctly handles the bus error (and all other errors) correctly.