### PR TITLE
fix(service): adjust when device discovery runs

### DIFF
--- a/cmd/cfm-service/main.go
+++ b/cmd/cfm-service/main.go
@@ -73,11 +73,20 @@ func main() {
 	data := datastore.DStore().GetDataStore()
 
 	// Check if there are any devices in the data store
-	bladeExist := len(data.ApplianceData) != 0
-	hostExist := len(data.HostData) != 0
+	hostsExist := len(data.HostData) != 0
+	appliancesExist := len(data.ApplianceData) != 0
+	bladesExist := false
+	if appliancesExist {
+		for _, applianceDatum := range data.ApplianceData {
+			bladesExist = len(applianceDatum.BladeData) != 0
+			if bladesExist {
+				break
+			}
+		}
+	}
 
 	// If there are no devices in the data store, do discovery, otherwise skip
-	if !bladeExist && !hostExist {
+	if !bladesExist && !hostsExist {
 		// Discover devices before loading datastore
 		bladeDevices, errBlade := services.DiscoverDevices(ctx, defaultApiService, "blade")
 		hostDevices, errHost := services.DiscoverDevices(ctx, defaultApiService, "cxl-host")


### PR DESCRIPTION
Want device discovery to run at service startup only when there are no blades and hosts.  However, don't want the presence of empty appliances to block the discovery code from running.  Code needs to check the blade map lengths directly to see if there are any blades present.