### PR TITLE
fix: change the layout for the offline devices

### DIFF
--- a/webui/src/components/Appliance/Appliances.vue
+++ b/webui/src/components/Appliance/Appliances.vue
@@ -2017,13 +2017,27 @@ export default {
     const selectedBladeStatus = computed(() => bladeStore.selectedBladeStatus);
 
     const statusColor = computed(() => {
-      return selectedBladeStatus.value === "online" ? "#6ebe4a" : "#ff9f40";
+      if (selectedBladeStatus.value === "online") {
+        return "#6ebe4a";
+      } else if (selectedBladeStatus.value === "unavailable") {
+        return "#ff9f40";
+      } else if (selectedBladeStatus.value === "offline") {
+        return "#b00020";
+      } else {
+        return "#B0B0B0"; // Default unknown status
+      }
     });
 
     const statusIcon = computed(() => {
-      return selectedBladeStatus.value === "online"
-        ? "mdi-check-circle"
-        : "mdi-close-circle";
+      if (selectedBladeStatus.value === "online") {
+        return "mdi-check-circle";
+      } else if (selectedBladeStatus.value === "unavailable") {
+        return "mdi-alert-circle";
+      } else if (selectedBladeStatus.value === "offline") {
+        return "mdi-close-circle";
+      } else {
+        return "mdi-help-circle"; // Default unknown status
+      }
     });
 
     // Methods to update state

--- a/webui/src/components/CXL-Hosts/CXL-Hosts.vue
+++ b/webui/src/components/CXL-Hosts/CXL-Hosts.vue
@@ -1132,7 +1132,7 @@ export default {
             hostPortStore.hostPortStore(newHostId),
             hostMemoryStore.hostMemoryStore(newHostId),
             hostMemoryDeviceStore.hostMemoryDeviceStore(newHostId),
-            hostStore.fetchHostById(newHostId)
+            hostStore.fetchHostById(newHostId),
           ]);
 
           // Update the URL with the new host ID
@@ -1152,13 +1152,27 @@ export default {
     const selectedHostStatus = computed(() => hostStore.selectedHostStatus);
 
     const statusColor = computed(() => {
-      return selectedHostStatus.value === "online" ? "#6ebe4a" : "#ff9f40";
+      if (selectedHostStatus.value === "online") {
+        return "#6ebe4a";
+      } else if (selectedHostStatus.value === "unavailable") {
+        return "#ff9f40";
+      } else if (selectedHostStatus.value === "offline") {
+        return "#b00020";
+      } else {
+        return "#B0B0B0"; // Default unknown status
+      }
     });
 
     const statusIcon = computed(() => {
-      return selectedHostStatus.value === "online"
-        ? "mdi-check-circle"
-        : "mdi-close-circle";
+      if (selectedHostStatus.value === "online") {
+        return "mdi-check-circle";
+      } else if (selectedHostStatus.value === "unavailable") {
+        return "mdi-alert-circle";
+      } else if (selectedHostStatus.value === "offline") {
+        return "mdi-close-circle";
+      } else {
+        return "mdi-help-circle"; // Default unknown status
+      }
     });
 
     // Methods to update state


### PR DESCRIPTION
Set up the layout for offline devices and the unknown status devices. If one device is not online, offline or unavailable status, it will be regraded as default unknown with gray color.
<img width="131" alt="image" src="https://github.com/user-attachments/assets/7958e56d-165c-40e0-b6af-7ec213db7aa1" />
<img width="134" alt="image" src="https://github.com/user-attachments/assets/00a9ca4b-261b-4866-b121-72f55e63d5fb" />
<img width="139" alt="image" src="https://github.com/user-attachments/assets/babe510b-0efe-4cc0-a4ff-f3c9ce6f9dc3" />
