### PR TITLE
fix(webui): make failed blade or host not affect the display of other devices

### DIFF
--- a/webui/src/components/Dashboard/Dashboard.vue
+++ b/webui/src/components/Dashboard/Dashboard.vue
@@ -47,83 +47,99 @@
         {{ "mdi-close" }}
       </v-icon>
     </div>
-        <v-card class="parent-card"
-          style="
-            width: 100%;
-            height: 100%;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-          "
-        >
-            <VueFlow
-              :nodes="nodes"
-              :edges="edges"
-              class="basic-flow"
-              :default-viewport="{ zoom: 1 }"
-              :min-zoom="0.2"
-              :max-zoom="4"
-              @node-click="handleNodeClick"
-            >
-              <Controls position="top-left">
-                <ControlButton title="Search" @click="toggleSearch">
-                  <v-icon>mdi-magnify</v-icon>
-                </ControlButton>
-              </Controls>
-            </VueFlow>
-          <v-card class="child-card"
-          style="
-            width: 20%;
-            height: 50%;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-          "
-        >
-          <v-card-text>
-            Devices
-            <v-list-item>
-              <v-list-item-title>
-                <v-icon color="#f2ae72" class="mr-2">mdi-rectangle</v-icon>
-                CMA
-              </v-list-item-title>
-            </v-list-item>
-            <v-list-item>
-              <v-list-item-title>
-                <v-icon color="#f2e394" class="mr-2">mdi-rectangle</v-icon>
-                Blade
-              </v-list-item-title>
-            </v-list-item>
-            <v-list-item>
-              <v-list-item-title>
-                <v-icon color="#d9ecd0" class="mr-2">mdi-rectangle</v-icon>
-                Host
-              </v-list-item-title>
-            </v-list-item>
-            <br>Status
-            <v-list-item>
-              <v-list-item-title>
-                <v-icon color="#6ebe4a" class="mr-2">mdi-rectangle-outline</v-icon>
-                online
-              </v-list-item-title>
-            </v-list-item>
-            <v-list-item>
-              <v-list-item-title>
-                <v-icon color="#b00020" class="mr-2">mdi-rectangle-outline</v-icon>
-                offline
-              </v-list-item-title>
-            </v-list-item>
-            <v-list-item>
-              <v-list-item-title>
-                <v-icon color="#ff9f40" class="mr-2">mdi-rectangle-outline</v-icon>
-                unavailable
-              </v-list-item-title>
-            </v-list-item>
-          </v-card-text>
-        </v-card>
-        </v-card>
+    <v-card
+      class="parent-card"
+      style="
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+      "
+    >
+      <VueFlow
+        :nodes="nodes"
+        :edges="edges"
+        class="basic-flow"
+        :default-viewport="{ zoom: 1 }"
+        :min-zoom="0.2"
+        :max-zoom="4"
+        @node-click="handleNodeClick"
+      >
+        <Controls position="top-left">
+          <ControlButton title="Search" @click="toggleSearch">
+            <v-icon>mdi-magnify</v-icon>
+          </ControlButton>
+        </Controls>
+      </VueFlow>
+      <v-card
+        class="child-card"
+        style="
+          width: 20%;
+          height: 50%;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+        "
+      >
+        <v-card-text>
+          Devices
+          <v-list-item>
+            <v-list-item-title>
+              <v-icon color="#f2ae72" class="mr-2">mdi-rectangle</v-icon>
+              CMA
+            </v-list-item-title>
+          </v-list-item>
+          <v-list-item>
+            <v-list-item-title>
+              <v-icon color="#f2e394" class="mr-2">mdi-rectangle</v-icon>
+              Blade
+            </v-list-item-title>
+          </v-list-item>
+          <v-list-item>
+            <v-list-item-title>
+              <v-icon color="#d9ecd0" class="mr-2">mdi-rectangle</v-icon>
+              Host
+            </v-list-item-title>
+          </v-list-item>
+          <br />Status
+          <v-list-item>
+            <v-list-item-title>
+              <v-icon color="#6ebe4a" class="mr-2"
+                >mdi-rectangle-outline</v-icon
+              >
+              online
+            </v-list-item-title>
+          </v-list-item>
+          <v-list-item>
+            <v-list-item-title>
+              <v-icon color="#b00020" class="mr-2"
+                >mdi-rectangle-outline</v-icon
+              >
+              offline
+            </v-list-item-title>
+          </v-list-item>
+          <v-list-item>
+            <v-list-item-title>
+              <v-icon color="#ff9f40" class="mr-2"
+                >mdi-rectangle-outline</v-icon
+              >
+              unavailable
+            </v-list-item-title>
+          </v-list-item>
+          <v-list-item>
+            <v-list-item-title>
+              <v-icon color="#B0B0B0" class="mr-2"
+                >mdi-rectangle-outline</v-icon
+              >
+              unknown
+            </v-list-item-title>
+          </v-list-item>
+        </v-card-text>
+      </v-card>
+    </v-card>
 
     <!-- The dialog of the warning before the adding the new discovered devices(blades or cxl-hosts) -->
     <v-dialog v-model="dialogNewDiscoveredDevices" max-width="600px">
@@ -144,7 +160,7 @@
             v-model="selectedBlades"
             :value="blade"
           ></v-checkbox>
-          <br>
+          <br />
           New Discovered Hosts:
           <v-checkbox
             v-for="(host, index) in discoveredHosts"
@@ -218,19 +234,18 @@
           size="112"
         ></v-icon>
         <h2 class="text-h5 mb-6">Congrats! New devices were added</h2>
-        <p class="mb-4 text-medium-emphasis text-body-2">
-          New blades:
-          <ul>
+        New blades:
+        <ul>
           <li v-for="(blade, index) in newBlades" :key="index">
             {{ blade.id }}
           </li>
-        </ul><br />New hosts: <br />
+        </ul>
+        <br />New hosts: <br />
         <ul>
           <li v-for="(host, index) in newHosts" :key="index">
             {{ host.id }}
           </li>
         </ul>
-        </p>
         <v-divider class="mb-4"></v-divider>
         <div class="text-end">
           <v-btn
@@ -269,7 +284,7 @@ export default {
     return {
       addNewDiscoveredDevicesProgressText:
         "Adding the selected devices, please wait...",
-      discoverDevicesProgressText:"Discovering devices, please wait...",
+      discoverDevicesProgressText: "Discovering devices, please wait...",
 
       dialogNewDiscoveredDevices: false,
       dialogAddNewDiscoveredDevicesWait: false,

--- a/webui/src/components/Dashboard/initial-control-elements.ts
+++ b/webui/src/components/Dashboard/initial-control-elements.ts
@@ -30,7 +30,7 @@ export const useControlData = () => {
       : [];
 
     const applianceNodes = applianceStore.applianceIds.flatMap(
-      (appliance, applianceIndex) => [
+      (appliance) => [
         {
           id: `appliance-${appliance.id}`,
           data: { label: appliance.id, url: `/appliances/${appliance.id}` },
@@ -38,7 +38,7 @@ export const useControlData = () => {
           style: { backgroundColor: useLayout().Colors.applianceColor, border: "none" },
           type: applianceNodeType,
         },
-        ...appliance.blades.map((blade, bladeIndex) => {
+        ...appliance.blades.map((blade) => {
           const borderColor = useLayout().borderColorChange(blade.status);
           return {
             id: `blade-${blade.id}`,
@@ -51,7 +51,7 @@ export const useControlData = () => {
       ]
     );
 
-    const hostNodes = hostStore.hostIds.map((host, index) => {
+    const hostNodes = hostStore.hostIds.map((host) => {
       const borderColor = useLayout().borderColorChange(host.status);
 
       return {

--- a/webui/src/components/Dashboard/initial-data-elements.ts
+++ b/webui/src/components/Dashboard/initial-data-elements.ts
@@ -17,7 +17,7 @@ export const useData = () => {
     const dataNodes = computed(() => {
         let currentYPosition = 0;
         const applianceNodes = applianceStore.applianceIds.flatMap(
-            (appliance, index) => {
+            (appliance) => {
                 const bladeCount = appliance.blades.length;
                 const applianceHeight = 50 + bladeCount * 50; // Adjust height based on number of blades
                 const applianceWidth = 270; // Width of the appliance node

--- a/webui/src/components/Dashboard/useLayout.ts
+++ b/webui/src/components/Dashboard/useLayout.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2024 Seagate Technology LLC and/or its Affiliates
 import dagre from '@dagrejs/dagre';
-import { Position, useVueFlow } from '@vue-flow/core';
+import { Position } from '@vue-flow/core';
 import { ref } from 'vue';
 
 /**
@@ -18,7 +18,7 @@ export function measureText(text: string, font = '16px Arial') {
     width: width,
     height: parseInt(font, 10) // Assuming height is roughly the font size
   };
-};
+}
 
 export const Colors = {
   applianceColor: '#f2ae72',
@@ -30,19 +30,17 @@ export const Colors = {
 export function borderColorChange(status: string | undefined) {
   switch (status) {
     case "online":
-      return "#6ebe4a"; // green
+      return "#6ebe4a"; // Green
     case "offline":
       return "#b00020"; // Red
     case "unavailable":
       return "#ff9f40"; // Orange
     default:
-      return "#ffffff"; // White
+      return "#B0B0B0"; // Gray
   }
-};
+}
 
 export function useLayout() {
-  const { findNode } = useVueFlow();
-
   const graph = ref(new dagre.graphlib.Graph());
 
   const previousDirection = ref('LR');

--- a/webui/src/components/Stores/ApplianceStore.ts
+++ b/webui/src/components/Stores/ApplianceStore.ts
@@ -122,16 +122,27 @@ export const useApplianceStore = defineStore("appliance", {
                 ?.slice(0, -2) as string;
               // Store blade in blades
               if (bladeId) {
-                const responseOfBlade = await defaultApi.bladesGetById(
-                  applianceId,
-                  bladeId
-                );
-                const response = {
-                  id: responseOfBlade.data.id,
-                  ipAddress: responseOfBlade.data.ipAddress,
-                  status: responseOfBlade.data.status,
-                };
-                associatedBlades.push(response);
+                try {
+                  const responseOfBlade = await defaultApi.bladesGetById(applianceId, bladeId);
+
+                  const response = {
+                    id: responseOfBlade.data.id,
+                    ipAddress: responseOfBlade.data.ipAddress,
+                    status: responseOfBlade.data.status,
+                  };
+
+                  associatedBlades.push(response);
+                } catch (bladeError) {
+                  console.error(`Error fetching blade ${bladeId}:`, bladeError);
+
+                  // Push the failed blade with an empty status
+                  // TODO: Get the status for the failed blade from cfm-service
+                  associatedBlades.push({
+                    id: bladeId,
+                    ipAddress: "",
+                    status: "",
+                  });
+                }
               }
             }
             this.applianceIds.push({

--- a/webui/src/components/Stores/HostStore.ts
+++ b/webui/src/components/Stores/HostStore.ts
@@ -55,17 +55,31 @@ export const useHostStore = defineStore("host", {
             .pop()
             ?.slice(0, -2) as string;
           // Get host by id
-          const detailsResponseOfHost = await defaultApi.hostsGetById(hostId);
+          if (hostId) {
+            try {
+              const detailsResponseOfHost = await defaultApi.hostsGetById(hostId);
 
-          // Store host in hosts
-          if (detailsResponseOfHost) {
-            this.hosts.push(detailsResponseOfHost.data);
-            const host = {
-              id: detailsResponseOfHost.data.id,
-              ipAddress: detailsResponseOfHost.data.ipAddress,
-              status: detailsResponseOfHost.data.status,
-            };
-            this.hostIds.push(host);
+              // Store host in hosts
+              if (detailsResponseOfHost) {
+                this.hosts.push(detailsResponseOfHost.data);
+                const host = {
+                  id: detailsResponseOfHost.data.id,
+                  ipAddress: detailsResponseOfHost.data.ipAddress,
+                  status: detailsResponseOfHost.data.status,
+                };
+                this.hostIds.push(host);
+              }
+            }
+            catch (hostError) {
+              console.error(`Error fetching host ${hostId}:`, hostError);
+              // Push the failed host with an empty status
+              // TODO: Get the status for the failed host from cfm-service
+              this.hostIds.push({
+                id: hostId,
+                ipAddress: "",
+                status: "",
+              });
+            }
           }
         }
       } catch (error) {


### PR DESCRIPTION
Fixed issue where when getting blade by id failed, all the blades in the same appliance and the associated appliance are also not displayed in the dashboard. And the same for failed hosts.