### PR TITLE
feat(webui): display of failed added devices in the dashboard

### DIFF
--- a/webui/src/components/Dashboard/Dashboard.vue
+++ b/webui/src/components/Dashboard/Dashboard.vue
@@ -251,7 +251,10 @@
             <v-list-item v-for="(blade, index) in failedBlades" :key="index">
               <v-list-item-subtitle>
                 <v-icon left style="color: red">mdi-close-circle</v-icon>
-                {{ blade.name }}</v-list-item-subtitle
+                {{ blade.blade.name }}</v-list-item-subtitle
+              >
+              <v-list-item-subtitle>
+                {{ blade.error.message }}</v-list-item-subtitle
               >
             </v-list-item>
           </v-list>
@@ -272,7 +275,10 @@
             <v-list-item v-for="(host, index) in failedHosts" :key="index">
               <v-list-item-subtitle>
                 <v-icon left style="color: red">mdi-close-circle</v-icon>
-                {{ host.name }}</v-list-item-subtitle
+                {{ host.host.name }}</v-list-item-subtitle
+              >
+              <v-list-item-subtitle>
+                {{ host.error.message }}</v-list-item-subtitle
               >
             </v-list-item>
           </v-list>
@@ -386,9 +392,11 @@ export default {
             if (newAddedBlade) {
               this.newBlades.push(newAddedBlade);
             }
-
           } catch (error) {
-            this.failedBlades.push(this.selectedBlades[i]);
+            this.failedBlades.push({
+              blade: this.selectedBlades[i],
+              error: error,
+            });
             console.error("Error adding new discovered blade:", error);
           }
         }
@@ -406,9 +414,11 @@ export default {
             if (newAddedHost) {
               this.newHosts.push(newAddedHost);
             }
-            
           } catch (error) {
-            this.failedHosts.push(this.selectedHosts[i]);
+            this.failedHosts.push({
+              host: this.selectedHosts[i],
+              error: error,
+            });
             console.error("Error adding new discovered host:", error);
           }
         }

--- a/webui/src/components/Dashboard/Dashboard.vue
+++ b/webui/src/components/Dashboard/Dashboard.vue
@@ -220,37 +220,75 @@
     </v-dialog>
 
     <v-dialog v-model="dialogAddNewDiscoveredDevicesOutput" max-width="600px">
-      <v-sheet
+      <v-card
         elevation="12"
         max-width="600"
         rounded="lg"
         width="100%"
         class="pa-4 text-center mx-auto"
       >
-        <v-icon
-          class="mb-5"
-          color="success"
-          icon="mdi-check-circle"
-          size="112"
-        ></v-icon>
-        <h2 class="text-h5 mb-6">Congrats! New devices were added</h2>
-        New blades:
-        <ul>
-          <li v-for="(blade, index) in newBlades" :key="index">
-            {{ blade.id }}
-          </li>
-        </ul>
-        <br />New hosts: <br />
-        <ul>
-          <li v-for="(host, index) in newHosts" :key="index">
-            {{ host.id }}
-          </li>
-        </ul>
+        <v-alert
+          color="info"
+          icon="$info"
+          title="Results of adding devices"
+          variant="tonal"
+        ></v-alert>
+        <br />
+        <div class="d-flex align-items-center justify-center mb-2">
+          <v-icon
+            class="mr-2"
+            color="success"
+            icon="mdi-check-circle"
+            size="24"
+          ></v-icon>
+          <h2 class="text-h5 mb-2">Successfully added devices</h2>
+        </div>
+        <div v-if="newBlades && newBlades.length">
+          New blades:
+          <v-list>
+            <v-list-item v-for="(blade, index) in newBlades" :key="index">
+              <v-list-item-subtitle>{{ blade.id }}</v-list-item-subtitle>
+            </v-list-item>
+          </v-list>
+        </div>
+        <div v-if="newHosts && newHosts.length">
+          New hosts:
+          <v-list>
+            <v-list-item v-for="(host, index) in newHosts" :key="index">
+              <v-list-item-subtitle>{{ host.id }}</v-list-item-subtitle>
+            </v-list-item>
+          </v-list>
+        </div>
+        <div class="d-flex align-items-center justify-center mb-0">
+          <v-icon
+            class="mr-2"
+            color="red"
+            icon="mdi-close-circle"
+            size="24"
+          ></v-icon>
+          <h2 class="text-h5 mb-0">Failed to add devices</h2>
+        </div>
+        <div v-if="failedBlades && failedBlades.length">
+          Failed blades:
+          <v-list>
+            <v-list-item v-for="(blade, index) in failedBlades" :key="index">
+              {{ blade }}
+            </v-list-item>
+          </v-list>
+        </div>
+        <div v-if="failedHosts.length && failedHosts.length">
+          Failed hosts:
+          <v-list>
+            <v-list-item v-for="(host, index) in failedHosts" :key="index">
+              {{ host }}
+            </v-list-item>
+          </v-list>
+        </div>
         <v-divider class="mb-4"></v-divider>
         <div class="text-end">
           <v-btn
             class="text-none"
-            color="success"
+            color="info"
             rounded
             variant="flat"
             width="90"
@@ -260,7 +298,7 @@
             Done
           </v-btn>
         </div>
-      </v-sheet>
+      </v-card>
     </v-dialog>
   </v-container>
 </template>
@@ -299,6 +337,8 @@ export default {
 
       newBlades: [],
       newHosts: [],
+      failedBlades: [],
+      failedHosts: [],
     };
   },
 
@@ -328,6 +368,12 @@ export default {
     },
 
     async addDiscoveredDevices() {
+      // Initialize the new and failed devices
+      this.newBlades = [];
+      this.newHosts = [];
+      this.failedBlades = [];
+      this.failedHosts = [];
+
       this.dialogNewDiscoveredDevices = false;
       this.dialogAddNewDiscoveredDevicesWait = true;
 
@@ -346,6 +392,8 @@ export default {
 
             if (newAddedBlade) {
               this.newBlades.push(newAddedBlade);
+            } else {
+              this.failedBlades.push(this.selectedBlades[i].id);
             }
           } catch (error) {
             console.error("Error adding new discovered blade:", error);
@@ -363,6 +411,8 @@ export default {
             );
             if (newAddedHost) {
               this.newHosts.push(newAddedHost);
+            } else {
+              this.failedHosts.push(this.selectedHosts[i].id);
             }
           } catch (error) {
             console.error("Error adding new discovered host:", error);

--- a/webui/src/components/Dashboard/Dashboard.vue
+++ b/webui/src/components/Dashboard/Dashboard.vue
@@ -234,53 +234,46 @@
           variant="tonal"
         ></v-alert>
         <br />
-        <div class="d-flex align-items-center justify-center mb-2">
-          <v-icon
-            class="mr-2"
-            color="success"
-            icon="mdi-check-circle"
-            size="24"
-          ></v-icon>
-          <h2 class="text-h5 mb-2">Successfully added devices</h2>
-        </div>
-        <div v-if="newBlades && newBlades.length">
+        <div
+          v-if="
+            (newBlades && newBlades.length) ||
+            (failedBlades && failedBlades.length)
+          "
+        >
           New blades:
           <v-list>
             <v-list-item v-for="(blade, index) in newBlades" :key="index">
-              <v-list-item-subtitle>{{ blade.id }}</v-list-item-subtitle>
+              <v-list-item-subtitle>
+                <v-icon left style="color: green">mdi-check-circle</v-icon
+                >{{ blade.id }}</v-list-item-subtitle
+              >
+            </v-list-item>
+            <v-list-item v-for="(blade, index) in failedBlades" :key="index">
+              <v-list-item-subtitle>
+                <v-icon left style="color: red">mdi-close-circle</v-icon>
+                {{ blade.name }}</v-list-item-subtitle
+              >
             </v-list-item>
           </v-list>
         </div>
-        <div v-if="newHosts && newHosts.length">
+        <div
+          v-if="
+            (newHosts && newHosts.length) || (failedHosts && failedHosts.length)
+          "
+        >
           New hosts:
           <v-list>
             <v-list-item v-for="(host, index) in newHosts" :key="index">
-              <v-list-item-subtitle>{{ host.id }}</v-list-item-subtitle>
+              <v-list-item-subtitle
+                ><v-icon left style="color: green">mdi-check-circle</v-icon
+                >{{ host.id }}</v-list-item-subtitle
+              >
             </v-list-item>
-          </v-list>
-        </div>
-        <div class="d-flex align-items-center justify-center mb-0">
-          <v-icon
-            class="mr-2"
-            color="red"
-            icon="mdi-close-circle"
-            size="24"
-          ></v-icon>
-          <h2 class="text-h5 mb-0">Failed to add devices</h2>
-        </div>
-        <div v-if="failedBlades && failedBlades.length">
-          Failed blades:
-          <v-list>
-            <v-list-item v-for="(blade, index) in failedBlades" :key="index">
-              {{ blade }}
-            </v-list-item>
-          </v-list>
-        </div>
-        <div v-if="failedHosts.length && failedHosts.length">
-          Failed hosts:
-          <v-list>
             <v-list-item v-for="(host, index) in failedHosts" :key="index">
-              {{ host }}
+              <v-list-item-subtitle>
+                <v-icon left style="color: red">mdi-close-circle</v-icon>
+                {{ host.name }}</v-list-item-subtitle
+              >
             </v-list-item>
           </v-list>
         </div>
@@ -392,10 +385,10 @@ export default {
 
             if (newAddedBlade) {
               this.newBlades.push(newAddedBlade);
-            } else {
-              this.failedBlades.push(this.selectedBlades[i].id);
             }
+
           } catch (error) {
+            this.failedBlades.push(this.selectedBlades[i]);
             console.error("Error adding new discovered blade:", error);
           }
         }
@@ -409,12 +402,13 @@ export default {
             const newAddedHost = await hostStore.addDiscoveredHosts(
               this.selectedHosts[i]
             );
+
             if (newAddedHost) {
               this.newHosts.push(newAddedHost);
-            } else {
-              this.failedHosts.push(this.selectedHosts[i].id);
             }
+            
           } catch (error) {
+            this.failedHosts.push(this.selectedHosts[i]);
             console.error("Error adding new discovered host:", error);
           }
         }


### PR DESCRIPTION
Display of failed added devices in the dashboard.
Changed the results popup when adding new devices. Place a circle icon in front of successful devices and a circle icon in front of failed devices.
Old:
![image](https://github.com/user-attachments/assets/3bee1447-3758-4a02-bb16-51a7a2b0eedf)
New:
<img width="293" alt="image" src="https://github.com/user-attachments/assets/6bf6e515-19bd-4fb4-80ac-9774b50dc36c" />
