### PR TITLE
fix(webui): resolve the assign port empty issue

### DIFF
--- a/webui/src/components/Appliance/Memory.vue
+++ b/webui/src/components/Appliance/Memory.vue
@@ -407,11 +407,19 @@ export default {
         if (this.selectedMemoryRegion.memoryAppliancePort) {
           this.assignUnassignMemory.port =
             this.selectedMemoryRegion.memoryAppliancePort;
-          // If the memory region is unassigned, use the input port to assign
         } else {
-          this.assignUnassignMemory.port = this.assignPort;
-          // Reset assignPort
-          this.assignPort = "";
+          // If the memory region is unassigned, use the input port to assign if it is not empty
+          if (this.assignPort) {
+            this.assignUnassignMemory.port = this.assignPort;
+            // Reset assignPort
+            this.assignPort = "";
+            // If the input port is empty, stop assigning memory
+          } else {
+            this.assignUnassignMemoryError = "Assign port need to be selected.";
+            this.waitAssignUnassignMemory = false;
+            this.assignUnassignFailure = true;
+            return;
+          }
         }
 
         this.assignUnassignMemory.operation = operation;


### PR DESCRIPTION
When assigning an existing memory region to a specific port, if the user forgets to select the port, the system will continue the assignment process but won’t perform any action. The new code changes this behavior to display a failure popup in such scenario.
<img width="272" alt="image" src="https://github.com/user-attachments/assets/6b645f83-da6a-464e-9f43-00a56a57220f" />
