### PR TITLE
chore(webui): move Vite's Node API as ESM only

### DIFF
--- a/webui/package.json
+++ b/webui/package.json
@@ -2,6 +2,7 @@
   "name": "webui",
   "version": "1.x.x",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "sh generate-cert.sh && vite",
     "build": "vue-tsc --noEmit && vite build",


### PR DESCRIPTION
The CJS build of Vite's Node API is deprecated and will be removed in Vite 6. Need to update files or frameworks to import the ESM build of Vite instead.

The "vite" package will only export ESM code:

```
// ✅ Works
import { ... } from "vite"

// ✅ Works
const { ... } = await import("vite")

// ❌ Will not work
const { ... } = require("vite")
```

Here is the refer: https://vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated